### PR TITLE
Add `EnsuredImage` component to reload images when they fail

### DIFF
--- a/components/notifications-area.js
+++ b/components/notifications-area.js
@@ -2,9 +2,11 @@ const React = require( 'react' );
 const el = React.createElement;
 const Gridicon = require( 'gridicons' );
 const debugFactory = require( 'debug' );
-const debug = debugFactory( 'gitnews-menubar' );
 const date = require( 'date-fns' );
+const EnsuredImage = require( '@sirbrillig/ensured-image' );
 const { getNoteId } = require( '../lib/helpers' );
+
+const debug = debugFactory( 'gitnews-menubar' );
 
 function Notification( { note, openUrl, markRead } ) {
 	const onClick = () => {
@@ -15,7 +17,7 @@ function Notification( { note, openUrl, markRead } ) {
 	const timeString = date.distanceInWords( Date.now(), date.parse( note.updatedAt ), { addSuffix: true } );
 	const noteClass = note.unread ? ' notification__unread' : ' notification__read';
 	return el( 'div', { className: 'notification' + noteClass, onClick },
-		el( 'div', { className: 'notification__image' }, el( 'img', { src: note.commentAvatar } ) ),
+		el( 'div', { className: 'notification__image' }, el( EnsuredImage, { src: note.commentAvatar } ) ),
 		el( 'div', { className: 'notification__body' },
 			el( 'div', { className: 'notification__repo' }, note.repositoryFullName ),
 			el( 'div', { className: 'notification__title' }, note.title ),

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "Payton Swick <payton@foolord.com>",
   "license": "MIT",
   "dependencies": {
+    "@sirbrillig/ensured-image": "^1.0.0",
     "conf": "^1.0.0",
     "date-fns": "^1.28.4",
     "debug": "^2.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@sirbrillig/ensured-image@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@sirbrillig/ensured-image/-/ensured-image-1.0.0.tgz#50fa214f085673239b15fb718b10d069d8cb7e48"
+  dependencies:
+    prop-types "^15.5.10"
+    react "^15.6.1"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -359,7 +366,7 @@ cp-file@^3.1.0:
     pinkie-promise "^2.0.0"
     readable-stream "^2.1.4"
 
-create-react-class@^15.5.3:
+create-react-class@^15.5.3, create-react-class@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
   dependencies:
@@ -1929,6 +1936,16 @@ react@^15.5.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.7"
+
+react@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #3 

This component will notice when an avatar image fails to load (eg: when we are offline) and replace it with a placeholder. Then it will retry loading the image every minute until it is successful.

I extracted the component into its own lib: https://github.com/sirbrillig/ensured-image