### PR TITLE
Only preserve `seen` if not recently updated

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,10 +19,14 @@ function setToken( token ) {
 function mergeNotifications( prevNotes, nextNotes ) {
 	const getMatchingPrevNote = note => {
 		const found = prevNotes.filter( prevNote => getNoteId( prevNote ) === getNoteId( note ) );
-		return found.length ? found[ 0 ] : {};
+		return found.length ? found[ 0 ] : null;
 	};
+	const hasNoteUpdated = ( note, prevNote ) => ( note.updatedAt > prevNote.gitnewsSeenAt );
 	return nextNotes.map( note => {
-		note.gitnewsSeen = getMatchingPrevNote( note ).gitnewsSeen;
+		const previousNote = getMatchingPrevNote( note );
+		if ( previousNote && ! hasNoteUpdated( note, previousNote ) ) {
+			return Object.assign( {}, note, { gitnewsSeen: previousNote.gitnewsSeen } );
+		}
 		return note;
 	} );
 }

--- a/lib/reducer.js
+++ b/lib/reducer.js
@@ -43,7 +43,7 @@ function reducer( state, action ) {
 			return Object.assign( {}, state, { notes } );
 		}
 		case 'MARK_ALL_NOTES_SEEN': {
-			const notes = state.notes.map( note => Object.assign( note, { gitnewsSeen: true } ) );
+			const notes = state.notes.map( note => Object.assign( note, { gitnewsSeen: true, gitnewsSeenAt: Date.now() } ) );
 			return Object.assign( {}, state, { notes } );
 		}
 		case 'CHANGE_TOKEN':

--- a/tests/reducer.js
+++ b/tests/reducer.js
@@ -38,10 +38,11 @@ describe( 'reducer', function() {
 	} );
 
 	describe( 'NOTES_RETRIEVED', function() {
+		const now = Date.parse( '2017-08-12' );
 		const notes = [
-			{ id: 'a1', unread: true, title: 'test note 1' },
-			{ id: 'a2', unread: false, title: 'test note 2' },
-			{ id: 'a3', unread: true, title: 'test note 3' },
+			{ id: 'a1', unread: true, title: 'test note 1', updatedAt: now },
+			{ id: 'a2', unread: false, title: 'test note 2', updatedAt: now },
+			{ id: 'a3', unread: true, title: 'test note 3', updatedAt: now },
 		];
 
 		it( 'disables offline mode', function() {
@@ -96,6 +97,13 @@ describe( 'reducer', function() {
 			const action = { type: 'NOTES_RETRIEVED', notes };
 			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsSeen: true } ] }, action );
 			expect( result.notes.filter( note => note.gitnewsSeen ) ).to.have.length( 1 );
+		} );
+
+		it( 'replaces `seen` state for existing notifications with updates', function() {
+			const longAgo = Date.parse( '2017-08-01' );
+			const action = { type: 'NOTES_RETRIEVED', notes };
+			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsSeen: true, gitnewsSeenAt: longAgo } ] }, action );
+			expect( result.notes.filter( note => note.gitnewsSeen ) ).to.have.length( 0 );
 		} );
 	} );
 

--- a/tests/reducer.js
+++ b/tests/reducer.js
@@ -1,4 +1,4 @@
-/* globals describe, it */
+/* globals describe, it, beforeEach */
 const { reducer } = require( '../lib/reducer' );
 const { secsToMs } = require( '../lib/helpers' );
 const { expect } = require( 'chai' );
@@ -39,11 +39,15 @@ describe( 'reducer', function() {
 
 	describe( 'NOTES_RETRIEVED', function() {
 		const now = Date.parse( '2017-08-12' );
-		const notes = [
-			{ id: 'a1', unread: true, title: 'test note 1', updatedAt: now },
-			{ id: 'a2', unread: false, title: 'test note 2', updatedAt: now },
-			{ id: 'a3', unread: true, title: 'test note 3', updatedAt: now },
-		];
+		let notes = [];
+
+		beforeEach( function() {
+			notes = [
+				{ id: 'a1', unread: true, title: 'test note 1', updatedAt: now },
+				{ id: 'a2', unread: false, title: 'test note 2', updatedAt: now },
+				{ id: 'a3', unread: true, title: 'test note 3', updatedAt: now },
+			];
+		} );
 
 		it( 'disables offline mode', function() {
 			const action = { type: 'NOTES_RETRIEVED', notes };
@@ -102,7 +106,7 @@ describe( 'reducer', function() {
 		it( 'replaces `seen` state for existing notifications with updates', function() {
 			const longAgo = Date.parse( '2017-08-01' );
 			const action = { type: 'NOTES_RETRIEVED', notes };
-			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsSeen: true, gitnewsSeenAt: longAgo } ] }, action );
+			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsSeen: true, updatedAt: longAgo, gitnewsSeenAt: longAgo } ] }, action );
 			expect( result.notes.filter( note => note.gitnewsSeen ) ).to.have.length( 0 );
 		} );
 	} );


### PR DESCRIPTION
Fixes #28 by keeping track of _when_ a notification has been seen, and comparing that to when the notification was last updated.