### PR TITLE
Actively mark notifications as read on click

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const { reducer } = require( './lib/reducer' );
 const { fetcher } = require( './lib/gitnews-fetcher' );
 const { electronMiddleware } = require( './lib/electron-middleware' );
 const { configMiddleware } = require( './lib/config-middleware' );
+const { githubMiddleware } = require( './lib/github-middleware' );
 
 const el = React.createElement;
 const logger = createLogger( {
@@ -39,7 +40,7 @@ function runApp() {
 		console.error( 'Could not find main element' );
 		return;
 	}
-	const store = createStore( reducer, applyMiddleware( configMiddleware, electronMiddleware, fetcher, logger ) );
+	const store = createStore( reducer, applyMiddleware( configMiddleware, electronMiddleware, githubMiddleware, fetcher, logger ) );
 	ReactDOM.render(
 		el( Provider, { store },
 			el( AppWrapper, { quitApp, version }, App )

--- a/components/main-pane.js
+++ b/components/main-pane.js
@@ -33,7 +33,7 @@ function MainPane( {
 	if ( ! lastSuccessfulCheck ) {
 		return el( UncheckedNotice, { fetchingInProgress, openUrl } );
 	}
-	return el( NotificationsArea, { newNotes, readNotes, markRead, openUrl } );
+	return el( NotificationsArea, { newNotes, readNotes, markRead, openUrl, token } );
 }
 
 module.exports = MainPane;

--- a/components/notification.js
+++ b/components/notification.js
@@ -6,10 +6,10 @@ const EnsuredImage = require( '@sirbrillig/ensured-image' );
 
 const debug = debugFactory( 'gitnews-menubar' );
 
-function Notification( { note, openUrl, markRead } ) {
+function Notification( { note, openUrl, markRead, token } ) {
 	const onClick = () => {
 		debug( 'clicked on notification', note );
-		markRead( note );
+		markRead( token, note );
 		openUrl( note.commentUrl );
 	};
 	const timeString = date.distanceInWords( Date.now(), date.parse( note.updatedAt ), { addSuffix: true } );

--- a/components/notification.js
+++ b/components/notification.js
@@ -1,0 +1,29 @@
+const React = require( 'react' );
+const el = React.createElement;
+const debugFactory = require( 'debug' );
+const date = require( 'date-fns' );
+const EnsuredImage = require( '@sirbrillig/ensured-image' );
+
+const debug = debugFactory( 'gitnews-menubar' );
+
+function Notification( { note, openUrl, markRead } ) {
+	const onClick = () => {
+		debug( 'clicked on notification', note );
+		markRead( note );
+		openUrl( note.commentUrl );
+	};
+	const timeString = date.distanceInWords( Date.now(), date.parse( note.updatedAt ), { addSuffix: true } );
+	const noteClass = note.unread ? ' notification__unread' : ' notification__read';
+	const defaultAvatar = `https://avatars.io/twitter/${ note.repositoryFullName }`;
+	const avatarSrc = note.commentAvatar || note.repositoryOwnerAvatar || defaultAvatar;
+	return el( 'div', { className: 'notification' + noteClass, onClick },
+		el( 'div', { className: 'notification__image' }, el( EnsuredImage, { src: avatarSrc } ) ),
+		el( 'div', { className: 'notification__body' },
+			el( 'div', { className: 'notification__repo' }, note.repositoryFullName ),
+			el( 'div', { className: 'notification__title' }, note.title ),
+			el( 'div', { className: 'notification__time' }, timeString )
+		)
+	);
+}
+
+module.exports = Notification;

--- a/components/notifications-area.js
+++ b/components/notifications-area.js
@@ -17,9 +17,9 @@ function NoNotifications() {
 	);
 }
 
-function NotificationsArea( { newNotes, readNotes, markRead, openUrl } ) {
-	const noteRows = newNotes.length ? newNotes.map( note => el( Notification, { note, key: getNoteId( note ), markRead, openUrl } ) ) : el( NoNotifications );
-	const readNoteRows = readNotes.map( note => el( Notification, { note, key: getNoteId( note ), markRead, openUrl } ) );
+function NotificationsArea( { newNotes, readNotes, markRead, openUrl, token } ) {
+	const noteRows = newNotes.length ? newNotes.map( note => el( Notification, { note, key: getNoteId( note ), markRead, token, openUrl } ) ) : el( NoNotifications );
+	const readNoteRows = readNotes.map( note => el( Notification, { note, key: getNoteId( note ), markRead, token, openUrl } ) );
 	return el( 'div', { className: 'notifications-area' },
 		noteRows,
 		readNoteRows

--- a/components/notifications-area.js
+++ b/components/notifications-area.js
@@ -1,32 +1,8 @@
 const React = require( 'react' );
 const el = React.createElement;
 const Gridicon = require( 'gridicons' );
-const debugFactory = require( 'debug' );
-const date = require( 'date-fns' );
-const EnsuredImage = require( '@sirbrillig/ensured-image' );
+const Notification = require( '../components/notification' );
 const { getNoteId } = require( '../lib/helpers' );
-
-const debug = debugFactory( 'gitnews-menubar' );
-
-function Notification( { note, openUrl, markRead } ) {
-	const onClick = () => {
-		debug( 'clicked on notification', note );
-		markRead( note );
-		openUrl( note.commentUrl );
-	};
-	const timeString = date.distanceInWords( Date.now(), date.parse( note.updatedAt ), { addSuffix: true } );
-	const noteClass = note.unread ? ' notification__unread' : ' notification__read';
-	const defaultAvatar = `https://avatars.io/twitter/${ note.repositoryFullName }`;
-	const avatarSrc = note.commentAvatar || note.repositoryOwnerAvatar || defaultAvatar;
-	return el( 'div', { className: 'notification' + noteClass, onClick },
-		el( 'div', { className: 'notification__image' }, el( EnsuredImage, { src: avatarSrc } ) ),
-		el( 'div', { className: 'notification__body' },
-			el( 'div', { className: 'notification__repo' }, note.repositoryFullName ),
-			el( 'div', { className: 'notification__title' }, note.title ),
-			el( 'div', { className: 'notification__time' }, timeString )
-		)
-	);
-}
 
 function NoNotificationsIcon() {
 	return el( Gridicon, { icon: 'checkmark-circle', size: 36, className: 'no-notifications-icon' } );

--- a/lib/github-middleware.js
+++ b/lib/github-middleware.js
@@ -1,0 +1,17 @@
+const { markNotificationRead } = require( 'gitnews' );
+
+const githubMiddleware = store => next => action => { // eslint-disable-line no-unused-vars
+	switch ( action.type ) {
+		case 'MARK_NOTE_READ':
+			markNoteRead( action.token, action.note );
+	}
+	next( action );
+};
+
+function markNoteRead( token, note ) {
+	markNotificationRead( token, note );
+}
+
+module.exports = {
+	githubMiddleware,
+};

--- a/lib/reducer.js
+++ b/lib/reducer.js
@@ -75,8 +75,8 @@ function showConfig() {
 	return { type: 'SET_CURRENT_PANE', pane: PANE_CONFIG };
 }
 
-function markRead( note ) {
-	return { type: 'MARK_NOTE_READ', note };
+function markRead( token, note ) {
+	return { type: 'MARK_NOTE_READ', token, note };
 }
 
 function clearErrors() {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "electron-is-dev": "^0.1.2",
     "electron-unhandled": "^0.1.1",
     "get-latest-release": "^1.1.2",
-    "gitnews": "^3.0.0",
+    "gitnews": "^3.1.0",
     "gridicons": "^2.0.1",
     "lodash": "^4.17.4",
     "menubar": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,9 +1247,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gitnews@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/gitnews/-/gitnews-3.0.0.tgz#5ffe08c412e31cb542954fce27b972d6f45858a3"
+gitnews@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/gitnews/-/gitnews-3.1.0.tgz#faf2e6389bbdcb92f53c788288f9e5e7a4097c4d"
   dependencies:
     lodash.get "^4.4.2"
     md5-hex "^2.0.0"


### PR DESCRIPTION
When clicking on a notification, mark the notification as read on Github.

Fixes #37 

Requires that https://github.com/sirbrillig/gitnews/pull/11 be merged first.