### PR TITLE
Fix errors that won't disappear

### DIFF
--- a/components/errors-area.js
+++ b/components/errors-area.js
@@ -13,7 +13,10 @@ function ErrorMessage( { error } ) {
 function ErrorsArea( { errors, clearErrors } ) {
 	return el( 'div', { className: 'errors-area' },
 		errors.length > 0 ? el( ClearErrorsButton, { clearErrors } ) : null,
-		errors.map( error => el( ErrorMessage, { error, key: getErrorMessage( error ) + Date.now() } ) )
+		Object.values( errors.reduce( ( uniqueErrors, error ) => {
+			uniqueErrors[ getErrorMessage( error ) ] = error;
+			return uniqueErrors;
+		}, {} ) ).map( error => el( ErrorMessage, { error, key: getErrorMessage( error ) } ) )
 	);
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -48,6 +48,7 @@ function isOfflineCode( code ) {
 		'ECONNABORTED',
 		'ECONNRESET',
 		'ENETUNREACH',
+		'Z_BUF_ERROR',
 	];
 	return ( offlineCodes.includes( code ) );
 }


### PR DESCRIPTION
Some errors were not disappearing when clicking "hide errors". I'm still not 100% sure why that happens, but I think it might be because the React keys for each error were based on a timestamp.

This change does a few things:

- The timestamp was added to allow multiple indentical errors to show at the same time. We don't really need that so this changes the code to display only unique error messages and removes the timestamp.
- I've been getting a lot of Z_BUF_ERROR problems connecting to the Github API lately, so this adds that error to the common "offline" errors list. It's not really us who's offline, but it is Github, so that makes some sense. This could be confusing but it's better IMO than a pile of Z_BUF_ERROR errors.