### PR TITLE
Add demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The app uses [debug](https://github.com/visionmedia/debug), so you can enable al
 localStorage.setItem('debug', 'gitnews-menubar')
 ```
 
+Rather than use real data, you can use mock data by enabling demo mode. This also disables network side effects (like marking a notification as read). To do this, create a `.env` file in the source directory and include the following:
+
+```
+GITNEWS_DEMO_MODE=y
+```
+
 ### Building a package
 
 To create a packaged Mac OS App, first install dependencies by running `yarn` (you must have [yarn](https://yarnpkg.com/en/) installed for this to work).

--- a/src/common/lib/github-middleware.js
+++ b/src/common/lib/github-middleware.js
@@ -1,15 +1,19 @@
-const { markNotificationRead } = require( 'gitnews' );
+require('dotenv').config();
 
-const githubMiddleware = store => next => action => { // eslint-disable-line no-unused-vars
-	switch ( action.type ) {
+const { markNotificationRead } = require('gitnews');
+const isDemoMode = process.env.GITNEWS_DEMO_MODE ? true : false;
+
+// eslint-disable-next-line no-unused-vars
+const githubMiddleware = store => next => action => {
+	switch (action.type) {
 		case 'MARK_NOTE_READ':
-			markNoteRead( action.token, action.note );
+			isDemoMode || markNoteRead(action.token, action.note);
 	}
-	next( action );
+	next(action);
 };
 
-function markNoteRead( token, note ) {
-	markNotificationRead( token, note );
+function markNoteRead(token, note) {
+	markNotificationRead(token, note);
 }
 
 module.exports = {

--- a/src/common/lib/gitnews-fetcher.js
+++ b/src/common/lib/gitnews-fetcher.js
@@ -1,4 +1,6 @@
 /* globals window */
+require('dotenv').config();
+
 const debugFactory = require('debug');
 const {
 	logError,
@@ -36,10 +38,12 @@ const fetcher = store => next => action => {
 	performFetch(store.getState(), next);
 };
 
-function performFetch(
-	{ fetchingInProgress, token, fetchingStartedAt, isDemoMode },
-	next
-) {
+function performFetch({ fetchingInProgress, token, fetchingStartedAt }, next) {
+	let isDemoMode = false;
+	if (process.env.GITNEWS_DEMO_MODE) {
+		debug('demo mode enabled!');
+		isDemoMode = true;
+	}
 	const fetchingMaxTime = secsToMs(120); // 2 minutes
 	if (fetchingInProgress) {
 		const timeSinceFetchingStarted = Date.now() - (fetchingStartedAt || 0);

--- a/src/common/lib/gitnews-fetcher.js
+++ b/src/common/lib/gitnews-fetcher.js
@@ -99,16 +99,15 @@ async function getDemoNotifications() {
 		{
 			updatedAt: new Date('21 December 2019 14:48 UTC').toISOString(),
 			unread: true,
-			repositoryName: 'gitnews',
-			repositoryFullName: 'sirbrillig/gitnews',
-			title: 'Pieces of Eight',
+			repositoryName: 'gitnews-menubar',
+			repositoryFullName: 'sirbrillig/gitnews-menubar',
+			title: 'Brew Tea Properly',
 			type: 'PullRequest',
-			id: 'd568cb6b0a944a3d2c3e6230b0190f26',
+			id: '5682942812944a3d2c3e6230b0190f26',
 			repositoryOwnerAvatar:
 				'https://avatars1.githubusercontent.com/u/887802?v=4',
-			subjectUrl: 'https://github.com/Automattic/wp-calypso/pull/38435',
-			commentUrl:
-				'https://github.com/Automattic/wp-calypso/pull/38435#issuecomment-568611814',
+			subjectUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/65',
+			commentUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/65',
 			commentAvatar: 'https://avatars2.githubusercontent.com/u/2036909?v=4',
 			api: {
 				subject: {
@@ -120,20 +119,59 @@ async function getDemoNotifications() {
 		{
 			updatedAt: new Date('20 December 2019 14:52 UTC').toISOString(),
 			unread: true,
-			repositoryName: 'gitnews',
-			repositoryFullName: 'sirbrillig/gitnews',
-			title: 'Trysail Sail ho Corsair',
+			repositoryName: 'gitnews-menubar',
+			repositoryFullName: 'sirbrillig/gitnews-menubar',
+			title: 'Fix Teapot',
 			type: 'PullRequest',
 			id: '1234566b0a944a3d2c3e6230b0190f26',
 			repositoryOwnerAvatar:
 				'https://avatars1.githubusercontent.com/u/887802?v=4',
-			subjectUrl: 'https://github.com/Automattic/wp-calypso/pull/38435',
-			commentUrl:
-				'https://github.com/Automattic/wp-calypso/pull/38435#issuecomment-568611814',
+			subjectUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/44',
+			commentUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/44',
+			commentAvatar: 'https://avatars2.githubusercontent.com/u/2036909?v=4',
+			api: {
+				subject: {
+					state: 'closed',
+					merged: true,
+				},
+			},
+		},
+		{
+			updatedAt: new Date('20 December 2019 10:52 UTC').toISOString(),
+			unread: true,
+			repositoryName: 'gitnews-menubar',
+			repositoryFullName: 'sirbrillig/gitnews-menubar',
+			title: 'Teapot is Broken',
+			type: 'Issue',
+			id: '2967500023477777222e6230b0190f26',
+			repositoryOwnerAvatar:
+				'https://avatars1.githubusercontent.com/u/887802?v=4',
+			subjectUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/48',
+			commentUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/48',
 			commentAvatar: 'https://avatars2.githubusercontent.com/u/2036909?v=4',
 			api: {
 				subject: {
 					state: 'open',
+					merged: false,
+				},
+			},
+		},
+		{
+			updatedAt: new Date('20 November 2019 16:20 UTC').toISOString(),
+			unread: true,
+			repositoryName: 'gitnews-menubar',
+			repositoryFullName: 'sirbrillig/gitnews-menubar',
+			title: 'Tea is bitter',
+			type: 'Issue',
+			id: '4582894865123099522e6230b0190f26',
+			repositoryOwnerAvatar:
+				'https://avatars1.githubusercontent.com/u/887802?v=4',
+			subjectUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/35',
+			commentUrl: 'https://github.com/sirbrillig/gitnews-menubar/pull/35',
+			commentAvatar: 'https://avatars2.githubusercontent.com/u/2036909?v=4',
+			api: {
+				subject: {
+					state: 'closed',
 					merged: false,
 				},
 			},

--- a/src/common/lib/gitnews-fetcher.js
+++ b/src/common/lib/gitnews-fetcher.js
@@ -20,6 +20,10 @@ const {
 } = require('common/lib/reducer');
 
 const debug = debugFactory('gitnews-menubar');
+const isDemoMode = process.env.GITNEWS_DEMO_MODE ? true : false;
+if (isDemoMode) {
+	debug('demo mode enabled!');
+}
 
 const fetcher = store => next => action => {
 	// eslint-disable-line no-unused-vars
@@ -39,11 +43,6 @@ const fetcher = store => next => action => {
 };
 
 function performFetch({ fetchingInProgress, token, fetchingStartedAt }, next) {
-	let isDemoMode = false;
-	if (process.env.GITNEWS_DEMO_MODE) {
-		debug('demo mode enabled!');
-		isDemoMode = true;
-	}
 	const fetchingMaxTime = secsToMs(120); // 2 minutes
 	if (fetchingInProgress) {
 		const timeSinceFetchingStarted = Date.now() - (fetchingStartedAt || 0);

--- a/src/common/lib/gitnews-fetcher.js
+++ b/src/common/lib/gitnews-fetcher.js
@@ -1,98 +1,169 @@
 /* globals window */
-const debugFactory = require( 'debug' );
-const { logError, secsToMs, isOfflineCode, getErrorMessage, isGitHubOffline, isInvalidJson } = require( 'common/lib/helpers' );
-const { getNotifications } = require( 'gitnews' );
+const debugFactory = require('debug');
+const {
+	logError,
+	secsToMs,
+	isOfflineCode,
+	getErrorMessage,
+	isGitHubOffline,
+	isInvalidJson,
+} = require('common/lib/helpers');
+const { getNotifications } = require('gitnews');
 const {
 	changeToOffline,
 	fetchBegin,
 	fetchDone,
 	gotNotes,
 	addConnectionError,
-} = require( 'common/lib/reducer' );
+} = require('common/lib/reducer');
 
-const debug = debugFactory( 'gitnews-menubar' );
+const debug = debugFactory('gitnews-menubar');
 
-const fetcher = store => next => action => { // eslint-disable-line no-unused-vars
-	if ( action.type === 'CHANGE_TOKEN' ) {
-		performFetch( Object.assign( {}, store.getState(), { token: action.token } ), next );
-		return next( action );
+const fetcher = store => next => action => {
+	// eslint-disable-line no-unused-vars
+	if (action.type === 'CHANGE_TOKEN') {
+		performFetch(
+			Object.assign({}, store.getState(), { token: action.token }),
+			next
+		);
+		return next(action);
 	}
 
-	if ( action.type !== 'GITNEWS_FETCH_NOTIFICATIONS' ) {
-		return next( action );
+	if (action.type !== 'GITNEWS_FETCH_NOTIFICATIONS') {
+		return next(action);
 	}
 
-	performFetch( store.getState(), next );
+	performFetch(store.getState(), next);
 };
 
-function performFetch( { fetchingInProgress, token, fetchingStartedAt }, next ) {
-	const fetchingMaxTime = secsToMs( 120 ); // 2 minutes
-	if ( fetchingInProgress ) {
-		const timeSinceFetchingStarted = ( Date.now() - ( fetchingStartedAt || 0 ) );
-		if ( timeSinceFetchingStarted > fetchingMaxTime ) {
-			debug( `it has been too long since we started fetching (${ timeSinceFetchingStarted } ms). Giving up.` );
-			next( fetchDone() );
-			logError( new Error( 'Fetching timed out.' ) );
+function performFetch(
+	{ fetchingInProgress, token, fetchingStartedAt, isDemoMode },
+	next
+) {
+	const fetchingMaxTime = secsToMs(120); // 2 minutes
+	if (fetchingInProgress) {
+		const timeSinceFetchingStarted = Date.now() - (fetchingStartedAt || 0);
+		if (timeSinceFetchingStarted > fetchingMaxTime) {
+			debug(
+				`it has been too long since we started fetching (${timeSinceFetchingStarted} ms). Giving up.`
+			);
+			next(fetchDone());
+			logError(new Error('Fetching timed out.'));
 			return;
 		}
-		debug( 'skipping notifications check because we are already fetching' );
+		debug('skipping notifications check because we are already fetching');
 		return;
 	}
-	if ( ! window.navigator.onLine ) {
-		debug( 'skipping notifications check because we are offline' );
-		next( changeToOffline() );
+	if (!window.navigator.onLine) {
+		debug('skipping notifications check because we are offline');
+		next(changeToOffline());
 		return;
 	}
-	debug( 'fetching notifications in middleware' );
+	debug('fetching notifications in middleware');
 	// NOTE: After this point, any return action MUST disable fetchingInProgress
 	// or the app will get stuck never updating again.
-	next( fetchBegin() );
+	next(fetchBegin());
+	const getGithubNotifications = getFetcher(token, isDemoMode);
 	try {
-		getNotifications( token )
-			.then( notes => {
-				debug( 'notifications retrieved', notes );
-				next( fetchDone() );
-				next( gotNotes( notes ) );
-			} )
-			.catch( err => {
-				debug( 'fetching notifications failed with the error', err );
-				next( fetchDone() );
-				getErrorHandler( next )( err );
-			} );
-	} catch ( err ) {
-		debug( 'fetching notifications threw an error', err );
-		next( fetchDone() );
-		getErrorHandler( next )( err );
-		logError( err );
+		getGithubNotifications()
+			.then(notes => {
+				debug('notifications retrieved', notes);
+				next(fetchDone());
+				next(gotNotes(notes));
+			})
+			.catch(err => {
+				debug('fetching notifications failed with the error', err);
+				next(fetchDone());
+				getErrorHandler(next)(err);
+			});
+	} catch (err) {
+		debug('fetching notifications threw an error', err);
+		next(fetchDone());
+		getErrorHandler(next)(err);
+		logError(err);
 	}
 }
 
-function getErrorHandler( dispatch ) {
-	return function handleFetchError( err ) {
-		if ( err.code === 'GitHubTokenNotFound' ) {
-			debug( 'notifications check failed because there is no token' );
+function getFetcher(token, isDemoMode) {
+	if (isDemoMode) {
+		return () => getDemoNotifications();
+	}
+	return () => getNotifications(token);
+}
+
+async function getDemoNotifications() {
+	return [
+		{
+			updatedAt: new Date('21 December 2019 14:48 UTC').toISOString(),
+			unread: true,
+			repositoryName: 'gitnews',
+			repositoryFullName: 'sirbrillig/gitnews',
+			title: 'Pieces of Eight',
+			type: 'PullRequest',
+			id: 'd568cb6b0a944a3d2c3e6230b0190f26',
+			repositoryOwnerAvatar:
+				'https://avatars1.githubusercontent.com/u/887802?v=4',
+			subjectUrl: 'https://github.com/Automattic/wp-calypso/pull/38435',
+			commentUrl:
+				'https://github.com/Automattic/wp-calypso/pull/38435#issuecomment-568611814',
+			commentAvatar: 'https://avatars2.githubusercontent.com/u/2036909?v=4',
+			api: {
+				subject: {
+					state: 'open',
+					merged: false,
+				},
+			},
+		},
+		{
+			updatedAt: new Date('20 December 2019 14:52 UTC').toISOString(),
+			unread: true,
+			repositoryName: 'gitnews',
+			repositoryFullName: 'sirbrillig/gitnews',
+			title: 'Trysail Sail ho Corsair',
+			type: 'PullRequest',
+			id: '1234566b0a944a3d2c3e6230b0190f26',
+			repositoryOwnerAvatar:
+				'https://avatars1.githubusercontent.com/u/887802?v=4',
+			subjectUrl: 'https://github.com/Automattic/wp-calypso/pull/38435',
+			commentUrl:
+				'https://github.com/Automattic/wp-calypso/pull/38435#issuecomment-568611814',
+			commentAvatar: 'https://avatars2.githubusercontent.com/u/2036909?v=4',
+			api: {
+				subject: {
+					state: 'open',
+					merged: false,
+				},
+			},
+		},
+	];
+}
+
+function getErrorHandler(dispatch) {
+	return function handleFetchError(err) {
+		if (err.code === 'GitHubTokenNotFound') {
+			debug('notifications check failed because there is no token');
 			// Do nothing. The case of having no token is handled in the App component.
 			return;
 		}
-		if ( isOfflineCode( err.code ) ) {
-			debug( 'notifications check failed because we are offline' );
-			dispatch( changeToOffline() );
+		if (isOfflineCode(err.code)) {
+			debug('notifications check failed because we are offline');
+			dispatch(changeToOffline());
 			return;
 		}
-		if ( isGitHubOffline( err ) ) {
-			debug( 'notifications check failed because GitHub is offline' );
-			dispatch( changeToOffline() );
+		if (isGitHubOffline(err)) {
+			debug('notifications check failed because GitHub is offline');
+			dispatch(changeToOffline());
 			return;
 		}
-		if ( isInvalidJson( err ) ) {
-			debug( 'notifications check failed because json fetch failed' );
-			dispatch( changeToOffline() );
+		if (isInvalidJson(err)) {
+			debug('notifications check failed because json fetch failed');
+			dispatch(changeToOffline());
 			return;
 		}
-		const errorString = 'Error fetching notifications: ' + getErrorMessage( err );
-		console.error( errorString );
-		dispatch( addConnectionError( errorString ) );
-		logError( new Error( errorString ) );
+		const errorString = 'Error fetching notifications: ' + getErrorMessage(err);
+		console.error(errorString); //eslint-disable-line no-console
+		dispatch(addConnectionError(errorString));
+		logError(new Error(errorString));
 	};
 }
 

--- a/src/common/lib/reducer.js
+++ b/src/common/lib/reducer.js
@@ -16,6 +16,7 @@ const initialState = {
 	offline: false,
 	currentPane: PANE_NOTIFICATIONS,
 	isAutoLoadEnabled: false,
+	isDemoMode: false,
 };
 
 function reducer( state, action ) {
@@ -60,6 +61,10 @@ function reducer( state, action ) {
 			return Object.assign( {}, state, { offline: false, lastChecked: Date.now(), lastSuccessfulCheck: Date.now(), fetchRetryCount: 0, errors: [], fetchInterval: defaultFetchInterval, notes: mergeNotifications( state.notes, action.notes ) } );
 		case 'CHANGE_AUTO_LOAD':
 			return Object.assign( {}, state, { isAutoLoadEnabled: action.isEnabled } );
+		case 'DEMO_MODE_ENABLE':
+			return {...state, isDemoMode: true};
+		case 'DEMO_MODE_DISABLE':
+			return {...state, isDemoMode: false};
 	}
 	return state;
 }
@@ -144,6 +149,14 @@ function scrollToTop() {
 	return { type: 'SCROLL_TO_TOP' };
 }
 
+function enableDemoMode() {
+	return { type: 'DEMO_MODE_ENABLE' };
+}
+
+function disableDemoMode() {
+	return { type: 'DEMO_MODE_DISABLE' };
+}
+
 module.exports = {
 	reducer,
 	hideEditToken,
@@ -166,4 +179,6 @@ module.exports = {
 	setIcon,
 	changeAutoLoad,
 	scrollToTop,
+	enableDemoMode,
+	disableDemoMode,
 };

--- a/src/common/lib/reducer.js
+++ b/src/common/lib/reducer.js
@@ -16,7 +16,6 @@ const initialState = {
 	offline: false,
 	currentPane: PANE_NOTIFICATIONS,
 	isAutoLoadEnabled: false,
-	isDemoMode: false,
 };
 
 function reducer( state, action ) {
@@ -61,10 +60,6 @@ function reducer( state, action ) {
 			return Object.assign( {}, state, { offline: false, lastChecked: Date.now(), lastSuccessfulCheck: Date.now(), fetchRetryCount: 0, errors: [], fetchInterval: defaultFetchInterval, notes: mergeNotifications( state.notes, action.notes ) } );
 		case 'CHANGE_AUTO_LOAD':
 			return Object.assign( {}, state, { isAutoLoadEnabled: action.isEnabled } );
-		case 'DEMO_MODE_ENABLE':
-			return {...state, isDemoMode: true};
-		case 'DEMO_MODE_DISABLE':
-			return {...state, isDemoMode: false};
 	}
 	return state;
 }
@@ -149,14 +144,6 @@ function scrollToTop() {
 	return { type: 'SCROLL_TO_TOP' };
 }
 
-function enableDemoMode() {
-	return { type: 'DEMO_MODE_ENABLE' };
-}
-
-function disableDemoMode() {
-	return { type: 'DEMO_MODE_DISABLE' };
-}
-
 module.exports = {
 	reducer,
 	hideEditToken,
@@ -179,6 +166,4 @@ module.exports = {
 	setIcon,
 	changeAutoLoad,
 	scrollToTop,
-	enableDemoMode,
-	disableDemoMode,
 };

--- a/src/common/lib/serialize-middleware.js
+++ b/src/common/lib/serialize-middleware.js
@@ -1,28 +1,30 @@
 /* globals window */
+require('dotenv').config();
+
+const isDemoMode = process.env.GITNEWS_DEMO_MODE ? true : false;
 
 const serializeMiddleware = store => next => action => {
-	switch ( action.type ) {
+	switch (action.type) {
 		case 'MARK_NOTE_UNREAD':
 		case 'MARK_NOTE_READ':
 		case 'MARK_ALL_NOTES_SEEN':
-			// TODO: this needs to happen AFTER the reducer changes the state
-			writeState( { notes: store.getState().notes } );
+			isDemoMode || writeState({ notes: store.getState().notes });
 	}
-	next( action );
+	next(action);
 };
 
-function writeState( state ) {
-	window.localStorage.setItem( 'gitnews-state', JSON.stringify( state ) );
+function writeState(state) {
+	window.localStorage.setItem('gitnews-state', JSON.stringify(state));
 }
 
 function getState() {
-	const stateSting = window.localStorage.getItem( 'gitnews-state' );
-	if ( ! stateSting ) {
+	const stateSting = window.localStorage.getItem('gitnews-state');
+	if (!stateSting) {
 		return {};
 	}
 	try {
-		return JSON.parse( stateSting );
-	} catch ( error ) {
+		return JSON.parse(stateSting);
+	} catch (error) {
 		return {};
 	}
 }


### PR DESCRIPTION
This adds a demo mode that can be used for development. It uses mocked data and disables side effects. It can be enabled by adding a `.env` file to the development environment and including `GITNEWS_DEMO_MODE=y` in that file.