### PR TITLE
Clean up Header UI

### DIFF
--- a/src/common/lib/reducer.js
+++ b/src/common/lib/reducer.js
@@ -1,9 +1,4 @@
 const {
-	PANE_NOTIFICATIONS,
-	PANE_CONFIG,
-	PANE_TOKEN,
-} = require('common/lib/constants');
-const {
 	getToken,
 	secsToMs,
 	getNoteId,
@@ -24,7 +19,6 @@ const initialState = {
 	fetchInterval: defaultFetchInterval,
 	fetchRetryCount: 0,
 	offline: false,
-	currentPane: PANE_NOTIFICATIONS,
 	isAutoLoadEnabled: false,
 };
 
@@ -48,8 +42,6 @@ function reducer(state, action) {
 			});
 		case 'CLEAR_ERRORS':
 			return Object.assign({}, state, { errors: [] });
-		case 'SET_CURRENT_PANE':
-			return Object.assign({}, state, { currentPane: action.pane });
 		case 'MARK_NOTE_UNREAD':
 			return Object.assign({}, state, {
 				notes: state.notes.map(note => {
@@ -100,22 +92,6 @@ function reducer(state, action) {
 			return Object.assign({}, state, { isAutoLoadEnabled: action.isEnabled });
 	}
 	return state;
-}
-
-function hideEditToken() {
-	return { type: 'SET_CURRENT_PANE', pane: PANE_CONFIG };
-}
-
-function showEditToken() {
-	return { type: 'SET_CURRENT_PANE', pane: PANE_TOKEN };
-}
-
-function hideConfig() {
-	return { type: 'SET_CURRENT_PANE', pane: PANE_NOTIFICATIONS };
-}
-
-function showConfig() {
-	return { type: 'SET_CURRENT_PANE', pane: PANE_CONFIG };
 }
 
 function markRead(token, note) {
@@ -184,10 +160,6 @@ function scrollToTop() {
 
 module.exports = {
 	reducer,
-	hideEditToken,
-	showEditToken,
-	hideConfig,
-	showConfig,
 	markRead,
 	markUnread,
 	markAllNotesSeen,

--- a/src/renderer/components/app.js
+++ b/src/renderer/components/app.js
@@ -6,14 +6,14 @@ import debugFactory from 'debug';
 import Header from '../components/header';
 import ErrorsArea from '../components/errors-area';
 import MainPane from '../components/main-pane';
-import { PANE_CONFIG, PANE_NOTIFICATIONS } from 'common/lib/constants';
+import {
+	PANE_CONFIG,
+	PANE_NOTIFICATIONS,
+	PANE_TOKEN,
+} from 'common/lib/constants';
 import Poller from 'common/lib/poller';
 import { getSecondsUntilNextFetch } from 'common/lib/helpers';
 import {
-	hideEditToken,
-	showEditToken,
-	hideConfig,
-	showConfig,
 	markRead,
 	markUnread,
 	clearErrors,
@@ -40,6 +40,9 @@ class App extends React.Component {
 			return true;
 		};
 		this.fetcher = new Poller({ pollFunction });
+		this.state = {
+			currentPane: PANE_NOTIFICATIONS,
+		};
 	}
 
 	componentDidMount() {
@@ -97,7 +100,6 @@ class App extends React.Component {
 		const {
 			offline,
 			errors,
-			currentPane,
 			token,
 			lastSuccessfulCheck,
 			version,
@@ -116,6 +118,12 @@ class App extends React.Component {
 		debug('sending set-icon', nextIcon);
 		this.props.setIcon(nextIcon);
 
+		const { currentPane } = this.state;
+		const hideConfig = () => this.setState({ currentPane: PANE_NOTIFICATIONS });
+		const showConfig = () => this.setState({ currentPane: PANE_CONFIG });
+		const showEditToken = () => this.setState({ currentPane: PANE_TOKEN });
+		const hideEditToken = () => this.setState({ currentPane: PANE_CONFIG });
+
 		return (
 			<main>
 				<Header
@@ -126,11 +134,8 @@ class App extends React.Component {
 						lastChecked: this.props.lastChecked,
 						fetchInterval: this.props.fetchInterval,
 						showConfig:
-							token &&
-							currentPane === PANE_NOTIFICATIONS &&
-							this.props.showConfig,
-						hideConfig:
-							token && currentPane === PANE_CONFIG && this.props.hideConfig,
+							token && currentPane === PANE_NOTIFICATIONS && showConfig,
+						hideConfig: token && currentPane === PANE_CONFIG && hideConfig,
 						openUrl: this.props.openUrl,
 						fetchingInProgress,
 					}}
@@ -147,8 +152,8 @@ class App extends React.Component {
 					openUrl={this.props.openUrl}
 					changeToken={this.props.changeToken}
 					quitApp={this.props.quitApp}
-					hideEditToken={this.props.hideEditToken}
-					showEditToken={this.props.showEditToken}
+					hideEditToken={hideEditToken}
+					showEditToken={showEditToken}
 					markRead={this.props.markRead}
 					markUnread={this.props.markUnread}
 					checkForUpdates={this.props.checkForUpdates}
@@ -172,10 +177,6 @@ App.propTypes = {
 	markRead: PropTypes.func.isRequired,
 	markUnread: PropTypes.func.isRequired,
 	clearErrors: PropTypes.func.isRequired,
-	showEditToken: PropTypes.func.isRequired,
-	hideEditToken: PropTypes.func.isRequired,
-	hideConfig: PropTypes.func.isRequired,
-	showConfig: PropTypes.func.isRequired,
 	changeAutoLoad: PropTypes.func.isRequired,
 
 	// Values
@@ -184,7 +185,6 @@ App.propTypes = {
 	notes: PropTypes.array.isRequired,
 	offline: PropTypes.bool,
 	errors: PropTypes.array,
-	currentPane: PropTypes.string.isRequired,
 	token: PropTypes.string,
 	lastSuccessfulCheck: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
 	fetchingInProgress: PropTypes.bool,
@@ -198,7 +198,6 @@ function mapStateToProps(state) {
 		notes: state.notes,
 		offline: state.offline,
 		errors: state.errors,
-		currentPane: state.currentPane,
 		token: state.token,
 		lastSuccessfulCheck: state.lastSuccessfulCheck,
 		fetchingInProgress: state.fetchingInProgress,
@@ -209,10 +208,6 @@ function mapStateToProps(state) {
 }
 
 const actions = {
-	hideEditToken,
-	showEditToken,
-	hideConfig,
-	showConfig,
 	markRead,
 	markUnread,
 	clearErrors,

--- a/src/renderer/components/fetching-in-progress.js
+++ b/src/renderer/components/fetching-in-progress.js
@@ -1,9 +1,5 @@
 import React from 'react';
 
 export default function FetchingInProgress() {
-	return (
-		<div className="fetching-in-progress">
-			<span>fetching notifications...</span>
-		</div>
-	);
+	return <div className="fetching-in-progress">fetching notifications...</div>;
 }

--- a/src/renderer/components/header.js
+++ b/src/renderer/components/header.js
@@ -75,7 +75,11 @@ export default function Header({
 
 function SecondaryHeader({ lastSuccessfulCheck, fetchingInProgress }) {
 	if (fetchingInProgress) {
-		return <FetchingInProgress />;
+		return (
+			<div className="header__secondary">
+				<FetchingInProgress />
+			</div>
+		);
 	}
 	return (
 		<div className="header__secondary">

--- a/src/renderer/components/header.js
+++ b/src/renderer/components/header.js
@@ -5,7 +5,6 @@ import LastChecked from '../components/last-checked';
 import OfflineNotice from '../components/offline-notice';
 import FetchingInProgress from '../components/fetching-in-progress';
 import createUpdater from '../components/updater';
-import Vanisher from '../components/vanisher';
 
 const UpdatingLastChecked = createUpdater(LastChecked);
 const UpdatingOfflineNotice = createUpdater(OfflineNotice);
@@ -62,13 +61,13 @@ export default function Header({
 				fetchingInProgress={fetchingInProgress}
 				lastSuccessfulCheck={lastSuccessfulCheck}
 			/>
-			<Vanisher isVisible={offline}>
+			{offline && (
 				<UpdatingOfflineNotice
 					fetchNotifications={fetchNotifications}
 					lastChecked={lastChecked}
 					fetchInterval={fetchInterval}
 				/>
-			</Vanisher>
+			)}
 		</header>
 	);
 }

--- a/src/renderer/components/header.js
+++ b/src/renderer/components/header.js
@@ -58,11 +58,10 @@ export default function Header({
 				<Logo onClick={openLink} />
 				<span className="config-spacer"></span>
 			</div>
-			<div className="header__secondary">
-				{lastSuccessfulCheck && (
-					<UpdatingLastChecked lastSuccessfulCheck={lastSuccessfulCheck} />
-				)}
-			</div>
+			<SecondaryHeader
+				fetchingInProgress={fetchingInProgress}
+				lastSuccessfulCheck={lastSuccessfulCheck}
+			/>
 			<Vanisher isVisible={offline}>
 				<UpdatingOfflineNotice
 					fetchNotifications={fetchNotifications}
@@ -70,9 +69,19 @@ export default function Header({
 					fetchInterval={fetchInterval}
 				/>
 			</Vanisher>
-			<Vanisher isVisible={fetchingInProgress}>
-				<FetchingInProgress />
-			</Vanisher>
 		</header>
+	);
+}
+
+function SecondaryHeader({ lastSuccessfulCheck, fetchingInProgress }) {
+	if (fetchingInProgress) {
+		return <FetchingInProgress />;
+	}
+	return (
+		<div className="header__secondary">
+			{lastSuccessfulCheck && (
+				<UpdatingLastChecked lastSuccessfulCheck={lastSuccessfulCheck} />
+			)}
+		</div>
 	);
 }

--- a/src/renderer/components/notifications-area.js
+++ b/src/renderer/components/notifications-area.js
@@ -31,20 +31,16 @@ export default function NotificationsArea({
 	openUrl,
 	token,
 }) {
-	const noteRows = newNotes.length ? (
-		newNotes.map(note => (
-			<Notification
-				note={note}
-				key={getNoteId(note)}
-				markRead={markRead}
-				markUnread={markUnread}
-				token={token}
-				openUrl={openUrl}
-			/>
-		))
-	) : (
-		<NoNotifications />
-	);
+	const noteRows = newNotes.map(note => (
+		<Notification
+			note={note}
+			key={getNoteId(note)}
+			markRead={markRead}
+			markUnread={markUnread}
+			token={token}
+			openUrl={openUrl}
+		/>
+	));
 	const readNoteRows = readNotes.map(note => (
 		<Notification
 			note={note}
@@ -57,6 +53,7 @@ export default function NotificationsArea({
 	));
 	return (
 		<div className="notifications-area">
+			{newNotes.length === 0 && readNotes.length === 0 && <NoNotifications />}
 			{noteRows}
 			{readNoteRows}
 		</div>

--- a/src/renderer/components/notifications-area.js
+++ b/src/renderer/components/notifications-area.js
@@ -3,22 +3,23 @@ import Gridicon from 'gridicons';
 import Notification from '../components/notification';
 import { getNoteId } from 'common/lib/helpers';
 
-function NoNotificationsIcon() {
+function NoNotificationsIcon({ children }) {
 	return (
-		<Gridicon
-			icon="checkmark-circle"
-			size={36}
-			className="no-notifications-icon"
-		/>
+		<div>
+			<Gridicon
+				icon="checkmark-circle"
+				size={36}
+				className="no-notifications-icon"
+			/>
+			{children}
+		</div>
 	);
 }
 
 function NoNotifications() {
 	return (
 		<div className="no-notifications">
-			<div>
-				<NoNotificationsIcon>No new notifications!</NoNotificationsIcon>
-			</div>
+			<NoNotificationsIcon>No notifications!</NoNotificationsIcon>
 		</div>
 	);
 }

--- a/src/renderer/components/vanisher.js
+++ b/src/renderer/components/vanisher.js
@@ -1,8 +1,0 @@
-import React from 'react';
-
-export default function Vanisher({ isVisible, children }) {
-	const className = isVisible
-		? 'vanisher vanisher--visible'
-		: 'vanisher vanisher--invisible';
-	return <div className={className}>{children}</div>;
-}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -148,6 +148,8 @@ header h1 {
   padding: 4px 5px;
   background-color: #24292e;
   font-size: 0.9em;
+  position: fixed;
+  bottom: 0;
 }
 
 .notification {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -308,19 +308,3 @@ main {
   flex-direction: column;
   width: 100%;
 }
-
-.vanisher {
-  width: 100%;
-  overflow: hidden;
-  transition: max-height 1s;
-}
-
-.vanisher--visible {
-  max-height: 300px;
-  transition: max-height 1s;
-}
-
-.vanisher--invisible {
-  max-height: 0;
-  transition: max-height 1s;
-}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -129,7 +129,7 @@ header h1 {
 }
 
 .last-checked {
-  font-size: 0.7em;
+  font-size: 0.8em;
   text-align: center;
 }
 
@@ -139,9 +139,6 @@ header h1 {
 }
 
 .fetching-in-progress {
-  width: 100%;
-  padding: 4px 5px;
-  background-color: #24292e;
   font-size: 0.8em;
   text-align: center;
 }


### PR DESCRIPTION
This makes the following adjustments to the header:

- Merge the "last checked" and "fetching..." indicators, so the latter does not take up any additional space.
- Only show the "no notifications" icon (and its text, which was removed at some point; this restores it) when there are no notifications at all. It otherwise adds clutter to read notifications and makes the list jump when you read the last one. It also implies that unread notifications are the main use for this menu, when that's not the case.
- Stick "offline" notice to bottom instead of sliding it in under the header. The slide behavior pushed other elements around which was not great if you were about to click on something. This makes it hover at the bottom of the window.
- Move currentPane state to App. This means that when the app is reloaded, the current pane state will not be persisted, which I think is a better experience. If I reload when showing the config settings, I don't want to still be on the config page.