### PR TITLE
Collect urls to open while meta key is being pressed and open on release

### DIFF
--- a/src/renderer/components/notification.js
+++ b/src/renderer/components/notification.js
@@ -19,7 +19,7 @@ export default function Notification({
 		debug('clicked on notification', note, 'with metaKey', event.metaKey);
 		markRead(token, note);
 		openUrl(note.commentUrl, {
-			openInBackground: event.metaKey,
+			openInBackground: !! event.metaKey,
 		});
 	};
 	const timeString = date.distanceInWords(

--- a/src/renderer/components/notifications-area.js
+++ b/src/renderer/components/notifications-area.js
@@ -40,6 +40,7 @@ export default function NotificationsArea({
 	const openNotificationUrl = (url, options = {}) =>
 		options.openInBackground ? saveUrlToOpen(url) : openUrl(url, options);
 	const openSavedUrls = React.useCallback(() => {
+		debug('opening urls', urlsToOpen);
 		urlsToOpen.map(openUrl);
 		setUrlsToOpen([]);
 	}, [openUrl, urlsToOpen]);


### PR DESCRIPTION
https://github.com/sirbrillig/gitnews-menubar/pull/75 added the ability to command-click notifications to open them in the background. However, due to [this Chrome bug, it doesn't really work](https://github.com/electron/electron/issues/12492). This PR takes a more heavy handed approach by collecting the URLs that you click while the command key is being pressed, then opens them all at once when the key is released.