### PR TITLE
Persist notifications cache

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env"
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "author": "Payton Swick <payton@foolord.com>",
   "license": "MIT",
   "dependencies": {
-    "auto-launch": "^5.0.1",
     "conf": "^7.1.1",
     "date-fns": "^1.30.1",
     "debug": "^4.1.1",
@@ -56,10 +55,8 @@
     "@babel/preset-react": "^7.10.4",
     "chai": "^4.0.0",
     "chai-sinon": "^2.8.1",
-    "devtron": "^1.4.0",
     "electron": "^9.3.1",
     "electron-builder": "^22.8.0",
-    "electron-react-devtools": "^0.5.3",
     "electron-webpack": "^2.8.2",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run install-deps && npm run compile-for-production && npm run build-osx-package",
     "compile-for-production": "electron-webpack compile",
     "build-osx-package": "electron-builder",
-    "test": "NODE_PATH=./src mocha tests"
+    "test": "NODE_PATH=./src mocha --require '@babel/register' tests"
   },
   "keywords": [
     "menu",
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.4",
+    "@babel/register": "^7.12.10",
     "chai": "^4.0.0",
     "chai-sinon": "^2.8.1",
     "electron": "^9.3.1",

--- a/src/common/lib/config-middleware.js
+++ b/src/common/lib/config-middleware.js
@@ -8,6 +8,7 @@ const configMiddleware = store => next => action => { // eslint-disable-line no-
 	switch ( action.type ) {
 		case 'CHANGE_TOKEN':
 			setToken( action.token );
+			break;
 		case 'CHANGE_AUTO_LOAD':
 			changeAutoLoad( action.isEnabled );
 	}
@@ -15,13 +16,16 @@ const configMiddleware = store => next => action => { // eslint-disable-line no-
 };
 
 function changeAutoLoad( shouldEnable ) {
+	debug( 'changing auto load to', shouldEnable );
 	const autoLauncher = new AutoLaunch( { name: 'Gitnews' } );
 	autoLauncher.isEnabled()
 		.then( function( isEnabled ) {
 			if ( shouldEnable && ! isEnabled ) {
+				debug( 'enabling autoLauncher' );
 				return autoLauncher.enable();
 			}
 			if ( ! shouldEnable && isEnabled ) {
+				debug( 'disabling autoLauncher' );
 				return autoLauncher.disable();
 			}
 		} )
@@ -30,7 +34,6 @@ function changeAutoLoad( shouldEnable ) {
 		} )
 		.catch( function( err ) {
 			console.error( 'failed to change autoload to', shouldEnable, err );
-			// TODO: maybe send to sentry?
 		} );
 }
 

--- a/src/common/lib/config-middleware.js
+++ b/src/common/lib/config-middleware.js
@@ -1,4 +1,4 @@
-const { ipcRenderer, app } = require('electron');
+const { ipcRenderer, remote } = require('electron');
 const { setToken } = require('common/lib/helpers');
 const { setAutoLoadState } = require('common/lib/reducer');
 const debugFactory = require('debug');
@@ -13,7 +13,7 @@ const configMiddleware = store => next => action => {
 			break;
 		case 'CHANGE_AUTO_LOAD': {
 			changeAutoLoad(action.isEnabled);
-			const settings = app.getLoginItemSettings();
+			const settings = remote.app.getLoginItemSettings();
 			return next(setAutoLoadState(settings.openAtLogin));
 		}
 	}

--- a/src/common/lib/gitnews-fetcher.js
+++ b/src/common/lib/gitnews-fetcher.js
@@ -66,7 +66,7 @@ function performFetch({ fetchingInProgress, token, fetchingStartedAt }, next) {
 	next(fetchBegin());
 	const getGithubNotifications = getFetcher(token, isDemoMode);
 	try {
-		getGithubNotifications()
+		getGithubNotifications(1)
 			.then(notes => {
 				debug('notifications retrieved', notes);
 				next(fetchDone());
@@ -88,7 +88,11 @@ function getFetcher(token, isDemoMode) {
 	if (isDemoMode) {
 		return () => getDemoNotifications();
 	}
-	return () => getNotifications(token);
+	return pageNumber =>
+		getNotifications(token, {
+			per_page: 100,
+			page: pageNumber,
+		});
 }
 
 async function getDemoNotifications() {

--- a/src/common/lib/gitnews-fetcher.js
+++ b/src/common/lib/gitnews-fetcher.js
@@ -40,7 +40,13 @@ const fetcher = store => next => action => {
 };
 
 function performFetch(
-	{ fetchingInProgress, token, fetchingStartedAt, notes, lastSuccessfulCheck },
+	{
+		fetchingInProgress,
+		token,
+		fetchingStartedAt,
+		notes,
+		lastSuccessfulReadCheck,
+	},
 	next
 ) {
 	const fetchingMaxTime = secsToMs(120); // 2 minutes
@@ -69,9 +75,9 @@ function performFetch(
 	// we last fetched them
 	const shouldFetchRead =
 		notes.length === 0 ||
-		new Date() - new Date(lastSuccessfulCheck) >
+		new Date() - new Date(lastSuccessfulReadCheck) >
 			maxIntervalForPollingReadNotifications;
-	debug( 'should we fetch read notifications?', shouldFetchRead );
+	debug('should we fetch read notifications?', shouldFetchRead);
 	const getGithubNotifications = getFetcher(token, isDemoMode, shouldFetchRead);
 	try {
 		getGithubNotifications()

--- a/src/common/lib/helpers.js
+++ b/src/common/lib/helpers.js
@@ -2,7 +2,7 @@ const Conf = require('conf');
 const config = new Conf();
 
 const maxFetchInterval = secsToMs(300); // 5 minutes
-const maxReadNoteAge = secsToMs(minsToSecs(hoursToMins(4000))); // about 6 months
+const maxReadNoteAge = 6 * 30 * 24 * 60 * 60 * 1000; // about 6 months
 
 function getNoteId(note) {
 	return note.id;
@@ -39,7 +39,7 @@ function mergeNotifications(prevNotes, nextNotes) {
 
 function removeOutdatedNotifications(notes) {
 	const now = Date.now();
-	return notes.filter(note => now - note.updatedAt < maxReadNoteAge);
+	return notes.filter(note => now - new Date(note.updatedAt) < maxReadNoteAge);
 }
 
 const findNoteInNotes = (note, prevNotes) => {
@@ -50,7 +50,7 @@ const findNoteInNotes = (note, prevNotes) => {
 };
 
 const hasNoteUpdated = (note, prevNote) =>
-	note.updatedAt > prevNote.gitnewsSeenAt;
+	new Date(note.updatedAt) > new Date(prevNote.gitnewsSeenAt);
 
 function msToSecs(ms) {
 	return parseInt(ms * 0.001, 10);
@@ -58,14 +58,6 @@ function msToSecs(ms) {
 
 function secsToMs(secs) {
 	return secs * 1000;
-}
-
-function minsToSecs(mins) {
-	return 60 * mins;
-}
-
-function hoursToMins(hours) {
-	return 24 * hours;
 }
 
 function isOfflineCode(code) {

--- a/src/common/lib/helpers.js
+++ b/src/common/lib/helpers.js
@@ -22,10 +22,18 @@ function mergeNotifications(prevNotes, nextNotes) {
 		...nextNotes.map(note => {
 			const previousNote = findNoteInNotes(note, prevNotes);
 			if (previousNote && !hasNoteUpdated(note, previousNote)) {
-				return Object.assign({}, note, {
+				return {
+					...note,
 					gitnewsSeen: previousNote.gitnewsSeen,
 					gitnewsMarkedUnread: previousNote.gitnewsMarkedUnread,
-				});
+				};
+			}
+			// Always preserve local marked unread status
+			if (note.gitnewsMarkedUnread) {
+				return {
+					...note,
+					gitnewsMarkedUnread: previousNote.gitnewsMarkedUnread,
+				};
 			}
 			return note;
 		}),

--- a/src/common/lib/helpers.js
+++ b/src/common/lib/helpers.js
@@ -39,7 +39,14 @@ function mergeNotifications(prevNotes, nextNotes) {
 
 function removeOutdatedNotifications(notes) {
 	const now = Date.now();
-	return notes.filter(note => now - new Date(note.updatedAt) < maxReadNoteAge);
+	return notes.filter(note => {
+		const isUnread = note.unread || note.gitnewsMarkedUnread;
+		if (isUnread) {
+			return true;
+		}
+		const noteAge = now - new Date(note.updatedAt);
+		return noteAge < maxReadNoteAge;
+	});
 }
 
 const findNoteInNotes = (note, prevNotes) => {

--- a/src/common/lib/helpers.js
+++ b/src/common/lib/helpers.js
@@ -1,44 +1,74 @@
-const Conf = require( 'conf' );
+const Conf = require('conf');
 const config = new Conf();
 
-const maxFetchInterval = secsToMs( 300 ); // 5 minutes
+const maxFetchInterval = secsToMs(300); // 5 minutes
+const maxReadNoteAge = secsToMs(minsToSecs(hoursToMins(4000))); // about 6 months
 
-function getNoteId( note ) {
+function getNoteId(note) {
 	return note.id;
 }
 
 function getToken() {
-	return config.get( 'gitnews-token' ) || process.env.GITNEWS_TOKEN;
+	return config.get('gitnews-token') || process.env.GITNEWS_TOKEN;
 }
 
-function setToken( token ) {
-	config.set( 'gitnews-token', token );
+function setToken(token) {
+	config.set('gitnews-token', token);
 }
 
-function mergeNotifications( prevNotes, nextNotes ) {
-	const getMatchingPrevNote = note => {
-		const found = prevNotes.filter( prevNote => getNoteId( prevNote ) === getNoteId( note ) );
-		return found.length ? found[ 0 ] : null;
-	};
-	const hasNoteUpdated = ( note, prevNote ) => ( note.updatedAt > prevNote.gitnewsSeenAt );
-	return nextNotes.map( note => {
-		const previousNote = getMatchingPrevNote( note );
-		if ( previousNote && ! hasNoteUpdated( note, previousNote ) ) {
-			return Object.assign( {}, note, { gitnewsSeen: previousNote.gitnewsSeen, gitnewsMarkedUnread: previousNote.gitnewsMarkedUnread } );
-		}
-		return note;
-	} );
+function mergeNotifications(prevNotes, nextNotes) {
+	return [
+		// Include all new notes, retaining custom properties unless the note has been updated
+		...nextNotes.map(note => {
+			const previousNote = findNoteInNotes(note, prevNotes);
+			if (previousNote && !hasNoteUpdated(note, previousNote)) {
+				return Object.assign({}, note, {
+					gitnewsSeen: previousNote.gitnewsSeen,
+					gitnewsMarkedUnread: previousNote.gitnewsMarkedUnread,
+				});
+			}
+			return note;
+		}),
+		// Include all notes previously downloaded that are not in the latest data set
+		...prevNotes.filter(previousNote => {
+			const nextNote = findNoteInNotes(previousNote, nextNotes);
+			return !nextNote;
+		}),
+	];
 }
 
-function msToSecs( ms ) {
-	return parseInt( ms * 0.001, 10 );
+function removeOutdatedNotifications(notes) {
+	const now = Date.now();
+	return notes.filter(note => now - note.updatedAt < maxReadNoteAge);
 }
 
-function secsToMs( secs ) {
+const findNoteInNotes = (note, prevNotes) => {
+	const found = prevNotes.filter(
+		prevNote => getNoteId(prevNote) === getNoteId(note)
+	);
+	return found.length ? found[0] : null;
+};
+
+const hasNoteUpdated = (note, prevNote) =>
+	note.updatedAt > prevNote.gitnewsSeenAt;
+
+function msToSecs(ms) {
+	return parseInt(ms * 0.001, 10);
+}
+
+function secsToMs(secs) {
 	return secs * 1000;
 }
 
-function isOfflineCode( code ) {
+function minsToSecs(mins) {
+	return 60 * mins;
+}
+
+function hoursToMins(hours) {
+	return 24 * hours;
+}
+
+function isOfflineCode(code) {
 	const offlineCodes = [
 		'ENETDOWN',
 		'ENOTFOUND',
@@ -48,40 +78,42 @@ function isOfflineCode( code ) {
 		'ENETUNREACH',
 		'Z_BUF_ERROR',
 	];
-	return ( offlineCodes.includes( code ) );
+	return offlineCodes.includes(code);
 }
 
-function getFetchInterval( interval, retryCount ) {
-	const fetchInterval = interval * ( retryCount + 1 );
-	if ( fetchInterval > maxFetchInterval ) {
+function getFetchInterval(interval, retryCount) {
+	const fetchInterval = interval * (retryCount + 1);
+	if (fetchInterval > maxFetchInterval) {
 		return maxFetchInterval;
 	}
 	return fetchInterval;
 }
 
-function getErrorMessage( error ) {
+function getErrorMessage(error) {
 	error = error || {};
 	return [
 		error.status,
 		error.code,
 		error.statusText,
 		error.message,
-		( typeof error === 'string' ) ? error : null,
-		error.url ? `for url ${ error.url }` : '',
-	].filter( Boolean ).join( '; ' );
+		typeof error === 'string' ? error : null,
+		error.url ? `for url ${error.url}` : '',
+	]
+		.filter(Boolean)
+		.join('; ');
 }
 
-function isGitHubOffline( error ) {
-	return ( error.status && error.status.toString().startsWith( '5' ) );
+function isGitHubOffline(error) {
+	return error.status && error.status.toString().startsWith('5');
 }
 
-function isInvalidJson( error ) {
+function isInvalidJson(error) {
 	return error.type === 'invalid-json';
 }
 
-function getSecondsUntilNextFetch( lastChecked, fetchInterval ) {
-	const interval = ( fetchInterval - ( Date.now() - ( lastChecked || 0 ) ) );
-	return ( interval < 0 ) ? 0 : msToSecs( interval );
+function getSecondsUntilNextFetch(lastChecked, fetchInterval) {
+	const interval = fetchInterval - (Date.now() - (lastChecked || 0));
+	return interval < 0 ? 0 : msToSecs(interval);
 }
 
 module.exports = {
@@ -97,4 +129,5 @@ module.exports = {
 	isGitHubOffline,
 	isInvalidJson,
 	getSecondsUntilNextFetch,
+	removeOutdatedNotifications,
 };

--- a/src/common/lib/helpers.js
+++ b/src/common/lib/helpers.js
@@ -17,6 +17,8 @@ function setToken(token) {
 }
 
 function mergeNotifications(prevNotes, nextNotes) {
+	const didFetchReadNotifications = nextNotes.notes.some(note => !note.unread);
+
 	return [
 		// Include all new notes, retaining custom properties unless the note has been updated
 		...nextNotes.map(note => {
@@ -38,10 +40,21 @@ function mergeNotifications(prevNotes, nextNotes) {
 			return note;
 		}),
 		// Include all notes previously downloaded that are not in the latest data set
-		...prevNotes.filter(previousNote => {
-			const nextNote = findNoteInNotes(previousNote, nextNotes);
-			return !nextNote;
-		}),
+		...prevNotes
+			.filter(previousNote => !findNoteInNotes(previousNote, nextNotes))
+			.map(previousNote => {
+				// If a note has stopped being unread and we are not polling for read
+				// notifications, we will assume that note has been read.
+				const didNoteStopBeingUnread =
+					!didFetchReadNotifications && previousNote.unread;
+				if (didNoteStopBeingUnread) {
+					return {
+						...previousNote,
+						unread: false,
+					};
+				}
+				return previousNote;
+			}),
 	];
 }
 

--- a/src/common/lib/helpers.js
+++ b/src/common/lib/helpers.js
@@ -17,7 +17,7 @@ function setToken(token) {
 }
 
 function mergeNotifications(prevNotes, nextNotes) {
-	const didFetchReadNotifications = nextNotes.notes.some(note => !note.unread);
+	const didFetchReadNotifications = nextNotes.some(note => !note.unread);
 
 	return [
 		// Include all new notes, retaining custom properties unless the note has been updated

--- a/src/common/lib/reducer.js
+++ b/src/common/lib/reducer.js
@@ -3,6 +3,7 @@ const {
 	secsToMs,
 	getNoteId,
 	mergeNotifications,
+	removeOutdatedNotifications,
 	getFetchInterval,
 } = require('common/lib/helpers');
 
@@ -90,7 +91,9 @@ function reducer(state, action) {
 				fetchRetryCount: 0,
 				errors: [],
 				fetchInterval: defaultFetchInterval,
-				notes: mergeNotifications(state.notes, action.notes),
+				notes: removeOutdatedNotifications(
+					mergeNotifications(state.notes, action.notes)
+				),
 			});
 		case 'CHANGE_AUTO_LOAD':
 			return Object.assign({}, state, { isAutoLoadEnabled: action.isEnabled });

--- a/src/common/lib/reducer.js
+++ b/src/common/lib/reducer.js
@@ -1,12 +1,14 @@
-const {
+import {
 	getToken,
 	secsToMs,
 	getNoteId,
 	mergeNotifications,
 	removeOutdatedNotifications,
 	getFetchInterval,
-} = require('common/lib/helpers');
+} from 'common/lib/helpers';
+import debugFactory from 'debug';
 
+const debug = debugFactory('gitnews-menubar');
 const defaultFetchInterval = secsToMs(120);
 
 const initialState = {
@@ -26,7 +28,7 @@ const initialState = {
 	appVisible: false,
 };
 
-function reducer(state, action) {
+export function reducer(state, action) {
 	if (!state) {
 		state = initialState;
 	}
@@ -83,7 +85,11 @@ function reducer(state, action) {
 				fetchInterval: getFetchInterval(secsToMs(60), state.fetchRetryCount),
 				fetchRetryCount: state.fetchRetryCount + 1,
 			});
-		case 'NOTES_RETRIEVED':
+		case 'NOTES_RETRIEVED': {
+			const notes = removeOutdatedNotifications(
+				mergeNotifications(state.notes, action.notes)
+			);
+			debug('notes retrieved, merged, and filtered', notes);
 			return Object.assign({}, state, {
 				offline: false,
 				lastChecked: Date.now(),
@@ -91,10 +97,9 @@ function reducer(state, action) {
 				fetchRetryCount: 0,
 				errors: [],
 				fetchInterval: defaultFetchInterval,
-				notes: removeOutdatedNotifications(
-					mergeNotifications(state.notes, action.notes)
-				),
+				notes,
 			});
+		}
 		case 'CHANGE_AUTO_LOAD':
 			return Object.assign({}, state, { isAutoLoadEnabled: action.isEnabled });
 		case 'MUTE_REPO':
@@ -112,111 +117,86 @@ function reducer(state, action) {
 	return state;
 }
 
-function muteRepo(repo) {
+export function muteRepo(repo) {
 	return { type: 'MUTE_REPO', repo };
 }
 
-function unmuteRepo(repo) {
+export function unmuteRepo(repo) {
 	return { type: 'UNMUTE_REPO', repo };
 }
 
-function markRead(token, note) {
+export function markRead(token, note) {
 	return { type: 'MARK_NOTE_READ', token, note };
 }
 
-function markUnread(note) {
+export function markUnread(note) {
 	return { type: 'MARK_NOTE_UNREAD', note };
 }
 
-function clearErrors() {
+export function clearErrors() {
 	return { type: 'CLEAR_ERRORS' };
 }
 
-function markAllNotesSeen() {
+export function markAllNotesSeen() {
 	return { type: 'MARK_ALL_NOTES_SEEN' };
 }
 
-function changeToken(token) {
+export function changeToken(token) {
 	return { type: 'CHANGE_TOKEN', token };
 }
 
-function changeToOffline() {
+export function changeToOffline() {
 	return { type: 'OFFLINE' };
 }
 
-function gotNotes(notes) {
+export function gotNotes(notes) {
 	return { type: 'NOTES_RETRIEVED', notes };
 }
 
-function addConnectionError(error) {
+export function addConnectionError(error) {
 	return { type: 'ADD_CONNECTION_ERROR', error };
 }
 
-function fetchBegin() {
+export function fetchBegin() {
 	return { type: 'FETCH_BEGIN' };
 }
 
-function fetchDone() {
+export function fetchDone() {
 	return { type: 'FETCH_END' };
 }
 
-function fetchNotifications() {
+export function fetchNotifications() {
 	return { type: 'GITNEWS_FETCH_NOTIFICATIONS' };
 }
 
-function checkForUpdates() {
+export function checkForUpdates() {
 	return { type: 'CHECK_FOR_UPDATES' };
 }
 
-function openUrl(url, options) {
+export function openUrl(url, options) {
 	return { type: 'OPEN_URL', url, options };
 }
 
-function setIcon(icon) {
+export function setIcon(icon) {
 	return { type: 'SET_ICON', icon };
 }
 
-function changeAutoLoad(isEnabled) {
+export function changeAutoLoad(isEnabled) {
 	return { type: 'CHANGE_AUTO_LOAD', isEnabled };
 }
 
-function scrollToTop() {
+export function scrollToTop() {
 	return { type: 'SCROLL_TO_TOP' };
 }
 
-function setFilterType(filterType) {
+export function setFilterType(filterType) {
 	return { type: 'SET_FILTER_TYPE', filterType };
 }
 
-function markAppHidden() {
+export function markAppHidden() {
 	return { type: 'NOTE_APP_VISIBLE', visible: false };
 }
 
-function markAppShown() {
+export function markAppShown() {
 	return { type: 'NOTE_APP_VISIBLE', visible: true };
 }
-
-module.exports = {
-	reducer,
-	markRead,
-	markUnread,
-	markAllNotesSeen,
-	clearErrors,
-	changeToken,
-	changeToOffline,
-	gotNotes,
-	addConnectionError,
-	fetchBegin,
-	fetchDone,
-	fetchNotifications,
-	openUrl,
-	checkForUpdates,
-	setIcon,
-	changeAutoLoad,
-	scrollToTop,
-	muteRepo,
-	unmuteRepo,
-	setFilterType,
-	markAppHidden,
-	markAppShown,
-};

--- a/src/common/lib/reducer.js
+++ b/src/common/lib/reducer.js
@@ -19,6 +19,7 @@ const initialState = {
 	fetchingInProgress: false,
 	lastChecked: false,
 	lastSuccessfulCheck: false,
+	lastSuccessfulReadCheck: false,
 	fetchingStartedAt: false,
 	fetchInterval: defaultFetchInterval,
 	fetchRetryCount: 0,
@@ -89,11 +90,15 @@ export function reducer(state, action) {
 			const notes = removeOutdatedNotifications(
 				mergeNotifications(state.notes, action.notes)
 			);
+			const didFetchReadNotifications = action.notes.some(note => !note.unread);
 			debug('notes retrieved, merged, and filtered', notes);
 			return Object.assign({}, state, {
 				offline: false,
 				lastChecked: Date.now(),
 				lastSuccessfulCheck: Date.now(),
+				lastSuccessfulReadCheck: didFetchReadNotifications
+					? Date.now()
+					: state.lastSuccessfulReadCheck,
 				fetchRetryCount: 0,
 				errors: [],
 				fetchInterval: defaultFetchInterval,

--- a/src/common/lib/reducer.js
+++ b/src/common/lib/reducer.js
@@ -105,7 +105,7 @@ export function reducer(state, action) {
 				notes,
 			});
 		}
-		case 'CHANGE_AUTO_LOAD':
+		case 'SET_AUTO_LOAD':
 			return Object.assign({}, state, { isAutoLoadEnabled: action.isEnabled });
 		case 'MUTE_REPO':
 			return { ...state, mutedRepos: [...state.mutedRepos, action.repo] };
@@ -188,6 +188,10 @@ export function setIcon(icon) {
 
 export function changeAutoLoad(isEnabled) {
 	return { type: 'CHANGE_AUTO_LOAD', isEnabled };
+}
+
+export function setAutoLoadState(isEnabled) {
+	return { type: 'SET_AUTO_LOAD', isEnabled };
 }
 
 export function scrollToTop() {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -40,6 +40,7 @@ const bar = menubar({
 		width: 390,
 		height: 440,
 		webPreferences: {
+			enableRemoteModule: true,
 			nodeIntegration: true,
 		},
 	},

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -109,7 +109,7 @@ ipcMain.on('open-url', (event, url, options) => {
 	shell.openExternal(url, options);
 });
 
-ipcMain.on('set-open-at-login', shouldOpenAtLogin => {
+ipcMain.on('set-open-at-login', (event, shouldOpenAtLogin) => {
 	debug('checking open-at-login to change it to', shouldOpenAtLogin);
 	const settings = app.getLoginItemSettings();
 	if (settings.openAtLogin !== shouldOpenAtLogin) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -109,6 +109,17 @@ ipcMain.on('open-url', (event, url, options) => {
 	shell.openExternal(url, options);
 });
 
+ipcMain.on('set-open-at-login', shouldOpenAtLogin => {
+	debug('checking open-at-login to change it to', shouldOpenAtLogin);
+	const settings = app.getLoginItemSettings();
+	if (settings.openAtLogin !== shouldOpenAtLogin) {
+		debug('setting open-at-login to', shouldOpenAtLogin);
+		app.setLoginItemSettings({
+			openAtLogin: shouldOpenAtLogin,
+		});
+	}
+});
+
 function setIcon(type) {
 	if (!type) {
 		type = lastIconState;

--- a/src/renderer/components/app.js
+++ b/src/renderer/components/app.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { remote } from 'electron';
 import PropTypes from 'prop-types';
 import debugFactory from 'debug';
 import Header from '../components/header';
@@ -26,6 +27,7 @@ import {
 	muteRepo,
 	unmuteRepo,
 	setFilterType,
+	setAutoLoadState,
 } from 'common/lib/reducer';
 import SearchNotifications from './search-notifications';
 import doesNoteMatchFilter from 'common/lib/does-note-match-filter';
@@ -55,6 +57,9 @@ class App extends React.Component {
 		debug('App mounted');
 		debug('starting fetcher...');
 		this.fetcher.begin();
+		debug('synching open-at-login...');
+		const settings = remote.app.getLoginItemSettings();
+		this.props.setAutoLoadState(settings.openAtLogin);
 	}
 
 	componentWillUnmount() {
@@ -275,6 +280,7 @@ const actions = {
 	muteRepo,
 	unmuteRepo,
 	setFilterType,
+	setAutoLoadState,
 };
 
 export default connect(mapStateToProps, actions)(App);

--- a/src/renderer/components/app.js
+++ b/src/renderer/components/app.js
@@ -1,4 +1,3 @@
-import AutoLaunch from 'auto-launch';
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -54,16 +53,8 @@ class App extends React.Component {
 
 	componentDidMount() {
 		debug('App mounted');
+		debug('starting fetcher...');
 		this.fetcher.begin();
-		const autoLauncher = new AutoLaunch({ name: 'Gitnews' });
-		autoLauncher
-			.isEnabled()
-			.then(isEnabled => {
-				this.props.changeAutoLoad(isEnabled);
-			})
-			.catch(function(err) {
-				console.error('failed to fetch autoload', err); // eslint-disable-line no-console
-			});
 	}
 
 	componentWillUnmount() {

--- a/tests/reducer.js
+++ b/tests/reducer.js
@@ -85,27 +85,34 @@ describe( 'reducer', function() {
 			expect( result.fetchInterval ).to.not.equal( 9999 );
 		} );
 
-		it( 'saves new notifications', function() {
+		it( 'saves new notifications but ignores old read notifications', function() {
 			const action = { type: 'NOTES_RETRIEVED', notes };
 			const result = reducer( { notes: [] }, action );
-			expect( result.notes ).to.have.length( 3 );
+			expect( result.notes ).to.have.length( 2 );
 		} );
 
-		it( 'removes notifications not in new data', function() {
+		it( 'preserves notifications not in new data', function() {
 			const action = { type: 'NOTES_RETRIEVED', notes };
-			const result = reducer( { notes: [ { id: 'o1', title: 'test note' } ] }, action );
-			expect( result.notes.map( note => note.id ) ).to.not.include( 'o1' );
+			const result = reducer( { notes: [ { id: 'o1', title: 'test note', updatedAt: Date.now() } ] }, action );
+			expect( result.notes.map( note => note.id ) ).to.include( 'o1' );
+		} );
+
+		it( 'does not duplicate existing notifications if they also appear in new data', function() {
+			const action = { type: 'NOTES_RETRIEVED', notes };
+			const result = reducer( { notes: [ notes[0] ] }, action );
+			const resultsWithoutFirst = result.notes.slice(1);
+			expect( resultsWithoutFirst.map( note => note.id ) ).to.not.include( 'o1' );
 		} );
 
 		it( 'preserves `markedUnread` state for existing notifications', function() {
 			const action = { type: 'NOTES_RETRIEVED', notes };
-			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsMarkedUnread: true } ] }, action );
+			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsMarkedUnread: true, updatedAt: Date.now() } ] }, action );
 			expect( result.notes.filter( note => note.gitnewsMarkedUnread ) ).to.have.length( 1 );
 		} );
 
 		it( 'preserves `seen` state for existing notifications', function() {
 			const action = { type: 'NOTES_RETRIEVED', notes };
-			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsSeen: true } ] }, action );
+			const result = reducer( { notes: [ { id: 'a1', title: 'test note', gitnewsSeen: true, updatedAt: Date.now() } ] }, action );
 			expect( result.notes.filter( note => note.gitnewsSeen ) ).to.have.length( 1 );
 		} );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,17 @@
     "@babel/plugin-transform-react-jsx-source" "^7.10.4"
     "@babel/plugin-transform-react-pure-annotations" "^7.10.4"
 
+"@babel/register@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.12.10.tgz#19b87143f17128af4dbe7af54c735663b3999f60"
+  integrity sha512-EvX/BvMMJRAA3jZgILWgbsrHwBQvllC5T8B29McyME8DvkdOxk4ujESfrMvME8IHSDvWXrmMXxPvA/lx2gqPLQ==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.19"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/runtime@^7.1.2":
   version "7.7.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.6.tgz#d18c511121aff1b4f2cd1d452f1bac9601dd830f"
@@ -3825,7 +3836,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^2.1.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -5457,7 +5468,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^2.0.0:
+make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
@@ -5973,6 +5984,11 @@ node-loader@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/node-loader/-/node-loader-0.6.0.tgz#c797ef51095ed5859902b157f6384f6361e05ae8"
   integrity sha1-x5fvUQle1YWZArFX9jhPY2HgWug=
+
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-pre-gyp@^0.12.0:
   version "0.12.0"
@@ -6563,6 +6579,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pirates@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
+  dependencies:
+    node-modules-regexp "^1.0.0"
 
 pkg-dir@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,11 +1320,6 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-accessibility-developer-tools@^2.11.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz#3da0cce9d6ec6373964b84f35db7cfc3df7ab514"
-  integrity sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=
-
 acorn-jsx@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
@@ -1501,11 +1496,6 @@ app-builder-lib@22.8.0:
     semver "^7.3.2"
     temp-file "^3.3.7"
 
-applescript@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/applescript/-/applescript-1.0.0.tgz#bb87af568cad034a4e48c4bdaf6067a3a2701317"
-  integrity sha1-u4evVoytA0pOSMS9r2Bno6JwExc=
-
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -1679,17 +1669,6 @@ atomically@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/atomically/-/atomically-1.3.2.tgz#721156e5c4f03e768ab54f3e6c9dc550d4690761"
   integrity sha512-MAiqx5ir1nOoMeG2vLXJnj4oFROJYB1hMqa2aAo6GQVIkPdkIcrq9W9SR0OaRtvEowO7Y2bsXqKFuDMTO4iOAQ==
-
-auto-launch@^5.0.1:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/auto-launch/-/auto-launch-5.0.5.tgz#d14bd002b1ef642f85e991a6195ff5300c8ad3c0"
-  integrity sha512-ppdF4mihhYzMYLuCcx9H/c5TUOCev8uM7en53zWVQhyYAJrurd2bFZx3qQVeJKF2jrc7rsPRNN5cD+i23l6PdA==
-  dependencies:
-    applescript "^1.0.0"
-    mkdirp "^0.5.1"
-    path-is-absolute "^1.0.0"
-    untildify "^3.0.2"
-    winreg "1.2.4"
 
 babel-loader@^8.1.0:
   version "8.1.0"
@@ -2876,15 +2855,6 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
-devtron@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/devtron/-/devtron-1.4.0.tgz#b5e748bd6e95bbe70bfcc68aae6fe696119441e1"
-  integrity sha1-tedIvW6Vu+cL/MaKrm/mlhGUQeE=
-  dependencies:
-    accessibility-developer-tools "^2.11.0"
-    highlight.js "^9.3.0"
-    humanize-plus "^1.8.1"
-
 diff@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -3157,11 +3127,6 @@ electron-publish@22.8.0:
     fs-extra "^9.0.1"
     lazy-val "^1.0.4"
     mime "^2.4.6"
-
-electron-react-devtools@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/electron-react-devtools/-/electron-react-devtools-0.5.3.tgz#c74edb1245dc1cfe1380b93016cd4eb588ed00b7"
-  integrity sha1-x07bEkXcHP4TgLkwFs1OtYjtALc=
 
 electron-to-chromium@^1.3.488:
   version "1.3.515"
@@ -4371,11 +4336,6 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^9.3.0:
-  version "9.18.5"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
-  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4562,11 +4522,6 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
-
-humanize-plus@^1.8.1:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
-  integrity sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=
 
 husky@^4.2.5:
   version "4.2.5"
@@ -8442,11 +8397,6 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-untildify@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.3.tgz#1e7b42b140bcfd922b22e70ca1265bfe3634c7c9"
-  integrity sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==
-
 upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
@@ -8802,11 +8752,6 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
-
-winreg@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.4.tgz#ba065629b7a925130e15779108cf540990e98d1b"
-  integrity sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs=
 
 with-query@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Currently when notifications are fetched, we request both read and unread notifications from the server. The github API has a maximum of 100 notifications that can be retrieved per page at one time. Let's say that you have 200 notifications. Within the first 100 you have 5 unread, and within the second 100, you have 2 unread. In this situation, the server response (and therefore gitnews) will only show the 5 most recent unread and you'll never see the 2 unread in the second 100 because it's on a page we do not fetch.

Furthermore, if a notification is marked as unread, since the github API does not actually support that action, we mark our local cache of the notification instead; if that notification ever passes beyond the first 100 notifications returned by the server, then our local cache of the notification will effectively expire, making it seem to disappear.

In this PR we change how fetching works to resolve these issues.

First, we make our local cache persistent beyond each fetch. We merge it with the most recent response from the server so that we never remove a local notification we've cached even if the server doesn't have it any more. Since keeping notifications indefinitely is not sustainable either, we prune our cache ourselves based on a large interval of inactivity on the notification itself rather than the number of notifications after it.

Second, we change fetching itself to have two modes of operation. Most fetches will now only ask the server for unread notifications. This way you'd have to have more than 100 _unread_ notifications before some would not appear (this is still an issue that will need to be addressed somehow but should be less of an issue than it was previously since that 100 will no longer include read notifications). We will still fetch unread notifications on our first fetch (or any time there are no notifications in the cache) and then any time we haven't fetched read notifications for 20 minutes.

If a notification changes from unread to read after being fetched and within that 20 minute interval, it would remain in the local cache (incorrectly) as unread, so if we detect that an unread notification in our local cache is _not_ also returned by the server during unread polling, we will assume that it has been read and mark the local cache appropriately.

If a notification is unread or has been marked unread locally, we will never remove it from our local cache, even if it is older than our local expiration interval.

Fixes https://github.com/sirbrillig/gitnews-menubar/issues/96