### PR TITLE
Fix latest release detection

### DIFF
--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -132,12 +132,12 @@ export function createReducer() {
 				const newNotes = mergeNotifications(state.notes, action.notes);
 				const unseen = newNotes.filter((note) => !note.gitnewsSeen);
 				const unread = newNotes.filter((note) => note.unread);
-				window.electronApi.logMessage(
+				window.electronApi?.logMessage(
 					`Storing notifications in store. ${unseen.length} unseen/${unread.length} unread/${newNotes.length} total`,
 					'info'
 				);
 				unseen.forEach((note) => {
-					window.electronApi.logMessage(`Unseen: ${note.title}`, 'info');
+					window.electronApi?.logMessage(`Unseen: ${note.title}`, 'info');
 				});
 				return Object.assign({}, state, {
 					offline: false,

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -128,7 +128,17 @@ export function createReducer() {
 					fetchInterval: getFetchInterval(secsToMs(60), state.fetchRetryCount),
 					fetchRetryCount: state.fetchRetryCount + 1,
 				});
-			case 'NOTES_RETRIEVED':
+			case 'NOTES_RETRIEVED': {
+				const newNotes = mergeNotifications(state.notes, action.notes);
+				const unseen = newNotes.filter((note) => !note.gitnewsSeen);
+				const unread = newNotes.filter((note) => note.unread);
+				window.electronApi.logMessage(
+					`Storing notifications in store. ${unseen.length} unseen/${unread.length} unread/${newNotes.length} total`,
+					'info'
+				);
+				unseen.forEach((note) => {
+					window.electronApi.logMessage(`Unseen: ${note.title}`, 'info');
+				});
 				return Object.assign({}, state, {
 					offline: false,
 					isTokenInvalid: false,
@@ -139,6 +149,7 @@ export function createReducer() {
 					fetchInterval: defaultFetchInterval,
 					notes: mergeNotifications(state.notes, action.notes),
 				});
+			}
 			case 'CHANGE_AUTO_LOAD':
 				return Object.assign({}, state, {
 					isAutoLoadEnabled: action.isEnabled,

--- a/src/renderer/lib/updates.ts
+++ b/src/renderer/lib/updates.ts
@@ -17,9 +17,10 @@ async function getLatestRelease() {
 		'https://api.github.com/repos/sirbrillig/gitnews-menubar/releases/latest';
 	const response = await fetch(url);
 	const responseData: LatestReleaseResponse = await response.json();
-	const asset = responseData.assets
-		? responseData.assets.find((asset) => asset.name.includes('dmg'))
-		: null;
+	const asset =
+		responseData.assets && responseData.assets.length > 0
+			? responseData.assets[0]
+			: null;
 	if (!asset) {
 		console.error('Latest release not found in', responseData);
 		throw new Error("Couldn't find latest release.");
@@ -38,6 +39,10 @@ async function getInfoIfUpdateAvailable() {
 	const newVersion = latestVersionInfo.version;
 	const isUpdateAvailable =
 		semver.gt(newVersion, oldVersion) && !semver.prerelease(newVersion);
+	window.electronApi.logMessage(
+		`Found latest release ${newVersion}. Current version ${oldVersion}. Is update available? ${isUpdateAvailable}.`,
+		'info'
+	);
 	if (isUpdateAvailable) {
 		return latestVersionInfo;
 	}


### PR DESCRIPTION
Release detection assumes that we always have a .dmg filename. Since 1.9 is using .zip files, it cannot find it. This PR changes the detection to look for the first release asset, no matter the filename.