### PR TITLE
Store accounts in main store so they migrate properly

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,12 @@ import {
 import { menubar } from 'menubar';
 import isDev from 'electron-is-dev';
 import electronDebug from 'electron-debug';
-import { getToken, toggleLogging } from './lib/main-store';
+import {
+	getToken,
+	toggleLogging,
+	getAccounts,
+	setAccounts,
+} from './lib/main-store';
 import { getIconForState } from './lib/icon-path';
 import { version } from '../../package.json';
 import unhandled from 'electron-unhandled';
@@ -29,7 +34,7 @@ declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 
 dotEnv.config();
 
-const debug = debugFactory('gitnews-menubar:main');
+const debug = debugFactory('gitnews-menubar');
 
 debug('initializing version', version);
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -102,6 +102,14 @@ ipcMain.on('toggle-logging', (_event, isLogging: boolean) => {
 	toggleLogging(isLogging);
 });
 
+ipcMain.on('accounts:set', (_event, accounts: AccountInfo[]) => {
+	setAccounts(accounts);
+});
+
+ipcMain.handle('accounts:get', async () => {
+	return getAccounts();
+});
+
 ipcMain.on('set-icon', (_event, arg: unknown) => {
 	if (typeof arg !== 'string') {
 		logMessage('Failed to set icon: it is invalid', 'error');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,7 +26,7 @@ import {
 	markNotficationAsRead,
 } from './lib/github-interface';
 import { logMessage } from './lib/logging';
-import type { AccountInfo, Note } from '../shared-types';
+import type { AccountInfo, FetchErrorObject, Note } from '../shared-types';
 
 // These are provided by electron forge
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
@@ -163,7 +163,21 @@ ipcMain.handle('is-demo-mode:get', async () => {
 ipcMain.handle(
 	'notifications-for-account:get',
 	async (_event, account: AccountInfo) => {
-		return fetchNotificationsForAccount(account);
+		try {
+			const notes = await fetchNotificationsForAccount(account);
+			return notes;
+		} catch (error) {
+			// Electron IPC does not preserve Error objects so we must serialize what
+			// data we actually want. See
+			// https://github.com/electron/electron/issues/24427
+			logMessage(
+				`Failure while fetching notifications for account ${account.name}(${account.serverUrl})`,
+				'error'
+			);
+			return {
+				error: encodeError(account.id, error as Error),
+			};
+		}
 	}
 );
 
@@ -173,6 +187,21 @@ ipcMain.handle(
 		return markNotficationAsRead(note, account);
 	}
 );
+
+// Errors must be JS objects to go through IPC. See
+// https://github.com/electron/electron/issues/26338
+function encodeError(accountId: string, error: any): FetchErrorObject {
+	return {
+		name: error.name,
+		message: error.message,
+		code: error.code,
+		statusText: error.statusText,
+		status: error.status,
+		url: error.url,
+		type: error.type,
+		accountId,
+	};
+}
 
 function setIcon(type?: string) {
 	if (!type) {

--- a/src/main/lib/main-store.ts
+++ b/src/main/lib/main-store.ts
@@ -1,13 +1,20 @@
 import Store from 'electron-store';
+import type { AccountInfo } from '../../shared-types';
 
-// FIXME: store accounts data so it persists after upgrade
+/**
+ * The data here will be saved in the OS so it will be available after an
+ * upgrade or any other situation where the electron context (localStorage
+ * where the in-app settings are saved) is lost.
+ */
 interface StoreSchema {
+	accounts: AccountInfo[];
 	'gitnews-token': string;
 	'is-logging-enabled': boolean;
 }
 
 const store = new Store<StoreSchema>({
 	defaults: {
+		accounts: [],
 		'gitnews-token': '',
 		'is-logging-enabled': false,
 	},
@@ -23,4 +30,12 @@ export function isLoggingEnabled(): boolean {
 
 export function toggleLogging(isEnabled: boolean): void {
 	store.set('is-logging-enabled', isEnabled);
+}
+
+export function getAccounts(): AccountInfo[] {
+	return store.get('accounts');
+}
+
+export function setAccounts(accounts: AccountInfo[]): void {
+	store.set('accounts', accounts);
 }

--- a/src/main/lib/main-store.ts
+++ b/src/main/lib/main-store.ts
@@ -1,5 +1,6 @@
 import Store from 'electron-store';
 
+// FIXME: store accounts data so it persists after upgrade
 interface StoreSchema {
 	'gitnews-token': string;
 	'is-logging-enabled': boolean;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -22,6 +22,9 @@ const bridge: MainBridge = {
 		ipcRenderer.invoke('notifications-for-account:get', account),
 	markNotificationRead: (note: Note, account: AccountInfo) =>
 		ipcRenderer.invoke('mark-note-as-read', note, account),
+	saveAccounts: (accounts: AccountInfo[]) =>
+		ipcRenderer.send('accounts:set', accounts),
+	getAccounts: () => ipcRenderer.invoke('accounts:get'),
 };
 
 contextBridge.exposeInMainWorld('electronApi', bridge);

--- a/src/renderer/components/account-edit.tsx
+++ b/src/renderer/components/account-edit.tsx
@@ -82,9 +82,9 @@ export default function AccountEdit({
 				</div>
 				<div>
 					<p>
-						You must generate a GitHub authentication token so this app can see
-						your notifications. It will need the `notifications` and `repo`
-						scopes.
+						You must generate a GitHub authentication token ("Personal access
+						tokens (classic)") so this app can see your notifications. It will
+						need the `notifications` and `repo` scopes.
 					</p>
 					<label htmlFor="add-token-form__input">GitHub Token:</label>
 					<input

--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -7,7 +7,8 @@ import FetchingInProgress from '../components/fetching-in-progress';
 import createUpdater from '../components/updater';
 import FilterButton from './filter-button';
 import { PANE_NOTIFICATIONS } from '../lib/constants';
-import { AppPane, FilterType } from '../types';
+import { AppPane, AppReduxState, FilterType } from '../types';
+import { useSelector } from 'react-redux';
 
 const UpdatingLastChecked = createUpdater(LastChecked);
 const UpdatingOfflineNotice = createUpdater(OfflineNotice);
@@ -88,7 +89,7 @@ export default function Header({
 				fetchingInProgress={fetchingInProgress}
 				lastSuccessfulCheck={lastSuccessfulCheck}
 			/>
-			{isTokenInvalid && <InvalidTokenNotice />}
+			{isTokenInvalid && !fetchingInProgress && <InvalidTokenNotice />}
 			{!isTokenInvalid && offline && (
 				<UpdatingOfflineNotice
 					fetchNotifications={fetchNotifications}
@@ -125,10 +126,16 @@ function SecondaryHeader({
 }
 
 function InvalidTokenNotice() {
+	const accounts = useSelector((state: AppReduxState) => state.accounts);
+	const accountNames = accounts
+		.filter((account) => account.isInvalid)
+		.map((account) => account.name)
+		.join(', ');
 	return (
 		<div className="offline-notice">
 			<span>
-				The token is not working. Please double-check that it is correct!
+				Some of your accounts are not working: '{accountNames}'. Please
+				double-check your info!
 			</span>
 		</div>
 	);

--- a/src/renderer/components/main-pane.tsx
+++ b/src/renderer/components/main-pane.tsx
@@ -115,7 +115,7 @@ export default function MainPane({
 			<AccountEdit account={selectedAccount} showAccounts={showAccounts} />
 		);
 	}
-	if (currentPane === PANE_ACCOUNTS) {
+	if (currentPane === PANE_ACCOUNTS || isTokenInvalid) {
 		return (
 			<AccountList accounts={accounts} showAccountEdit={showAccountEdit} />
 		);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 
 import App from './components/app';
 import AppWrapper from './components/app-wrapper';
-import { initToken, setIsDemoMode } from './lib/reducer';
+import { initToken, setIsDemoMode, initAccounts } from './lib/reducer';
 import { store } from './lib/store';
 
 import './styles.css';
@@ -27,9 +27,14 @@ async function runApp() {
 
 	const isDemoMode = await window.electronApi.isDemoMode();
 	const token = await window.electronApi.getToken();
-	window.electronApi.logMessage('Initializing token to saved value', 'info');
+	const accounts = await window.electronApi.getAccounts();
+	window.electronApi.logMessage(
+		'Initializing accounts in app to data from store',
+		'info'
+	);
 	store.dispatch(setIsDemoMode(isDemoMode));
 	store.dispatch(initToken(token));
+	store.dispatch(initAccounts(accounts));
 
 	ReactDOM.render(
 		<Provider store={store}>

--- a/src/renderer/lib/config-middleware.ts
+++ b/src/renderer/lib/config-middleware.ts
@@ -16,6 +16,9 @@ export const configMiddleware: Middleware<{}, AppReduxState> =
 			case 'TOGGLE_LOGGING':
 				window.electronApi.toggleLogging(action.isLogging);
 				break;
+			case 'SET_ACCOUNTS':
+				window.electronApi.saveAccounts(action.accounts);
+				break;
 		}
 		next(action);
 	};

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -18,7 +18,13 @@ import {
 	addConnectionError,
 	setIsTokenInvalid,
 } from '../lib/reducer';
-import { AccountInfo, AppReduxState, Note, UnknownFetchError } from '../types';
+import {
+	AccountInfo,
+	AppReduxState,
+	FetchErrorObject,
+	Note,
+	UnknownFetchError,
+} from '../types';
 import { AppDispatch } from './store';
 import { createDemoNotifications } from './demo-mode';
 
@@ -118,13 +124,13 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 			next(fetchDone());
 			next(gotNotes(notes));
 		} catch (err) {
-			debug('fetching notifications threw an error', err);
+			debug('Fetching notifications threw an error', err);
 			window.electronApi.logMessage(
 				`Fetching notifications threw an error`,
 				'warn'
 			);
 			next(fetchDone());
-			getErrorHandler(next)(err as Error);
+			getErrorHandler(next)(err as FetchErrorObject);
 		}
 	}
 
@@ -139,6 +145,9 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 			let allNotes: Note[] = [];
 			for (const account of accounts) {
 				const notes = await fetchNotifications(account);
+				if ('error' in notes) {
+					throw notes.error;
+				}
 				allNotes = [...allNotes, ...notes];
 			}
 			return allNotes;
@@ -148,7 +157,9 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 	return fetcher;
 }
 
-async function fetchNotifications(account: AccountInfo): Promise<Note[]> {
+async function fetchNotifications(
+	account: AccountInfo
+): Promise<Note[] | { error: Error }> {
 	return window.electronApi.getNotificationsForAccount(account);
 }
 
@@ -162,13 +173,12 @@ async function getDemoNotifications(): Promise<Note[]> {
 
 export function getErrorHandler(dispatch: AppDispatch) {
 	return function handleFetchError(err: UnknownFetchError) {
-		// FIXME: handle invalid token for any account
 		if (typeof err === 'object' && isTokenInvalid(err)) {
-			const message = 'Notifications check failed the token is invalid';
+			const message = `Notifications check failed because the token is invalid for '${err.accountId ?? 'unknown'}'`;
 			debug(message);
 			window.electronApi.logMessage(message, 'warn');
 			dispatch(changeToOffline());
-			dispatch(setIsTokenInvalid(true));
+			dispatch(setIsTokenInvalid(err.accountId ?? 'unknown', true));
 			return;
 		}
 
@@ -221,7 +231,7 @@ export function getErrorHandler(dispatch: AppDispatch) {
 		window.electronApi.logMessage(message, 'error');
 		const errorString = 'Error fetching notifications: ' + getErrorMessage(err);
 		console.error(errorString); //eslint-disable-line no-console
-		console.error(err); //eslint-disable-line no-console
+		console.error('Raw error:', err); //eslint-disable-line no-console
 		dispatch(addConnectionError(errorString));
 	};
 }

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -124,7 +124,7 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 				'warn'
 			);
 			next(fetchDone());
-			getErrorHandler(next)(err as Error, state.token);
+			getErrorHandler(next)(err as Error);
 		}
 	}
 
@@ -161,41 +161,8 @@ async function getDemoNotifications(): Promise<Note[]> {
 }
 
 export function getErrorHandler(dispatch: AppDispatch) {
-	return function handleFetchError(
-		err: UnknownFetchError,
-		token: string | undefined = undefined
-	) {
-		// FIXME: handleFetchError should ignore state.token
-		if (
-			typeof err === 'object' &&
-			err.code === 'GitHubTokenNotFound' &&
-			!token
-		) {
-			const message =
-				'Notifications check failed because there is no token; taking no action';
-			debug(message);
-			window.electronApi.logMessage(message, 'info');
-			// Do nothing. The case of having no token is handled in the App component.
-			return;
-		}
-
-		if (
-			typeof err === 'object' &&
-			err.code === 'GitHubTokenNotFound' &&
-			token
-		) {
-			// This should never happen, I hope!
-			const message =
-				'Notifications check failed because there is no token, even though one is set';
-			debug(message);
-			window.electronApi.logMessage(message, 'error');
-			const errorString =
-				'Error fetching notifications: ' + getErrorMessage(err);
-			console.error(errorString); //eslint-disable-line no-console
-			dispatch(addConnectionError(errorString));
-			return;
-		}
-
+	return function handleFetchError(err: UnknownFetchError) {
+		// FIXME: handle invalid token for any account
 		if (typeof err === 'object' && isTokenInvalid(err)) {
 			const message = 'Notifications check failed the token is invalid';
 			debug(message);

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -54,8 +54,13 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 					'Accounts changed; fetching with updated accounts',
 					'info'
 				);
-				// FIXME: this does not use the new accounts for the fetch
-				performFetch(store.getState(), next);
+				performFetch(
+					{
+						...store.getState(),
+						accounts: action.accounts,
+					},
+					next
+				);
 				return next(action);
 			}
 

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -54,6 +54,7 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 					'Accounts changed; fetching with updated accounts',
 					'info'
 				);
+				// FIXME: this does not use the new accounts for the fetch
 				performFetch(store.getState(), next);
 				return next(action);
 			}
@@ -92,7 +93,7 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 			next(changeToOffline());
 			return;
 		}
-		if (!state.token) {
+		if (state.accounts.length < 1) {
 			next(changeToOffline());
 			return;
 		}
@@ -159,6 +160,7 @@ export function getErrorHandler(dispatch: AppDispatch) {
 		err: UnknownFetchError,
 		token: string | undefined = undefined
 	) {
+		// FIXME: handleFetchError should ignore state.token
 		if (
 			typeof err === 'object' &&
 			err.code === 'GitHubTokenNotFound' &&

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -91,7 +91,7 @@ export function isTokenInvalid(error: UnknownFetchError): boolean {
 	return Boolean(
 		typeof error === 'object' &&
 			error.status &&
-			error.status.toString() === '401'
+			error.status.toString().startsWith('4')
 	);
 }
 

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -53,6 +53,34 @@ const initialState: AppReduxState = {
 	selectedAccount: undefined,
 };
 
+function setAllAccountsValid(accounts: AccountInfo[]): AccountInfo[] {
+	return accounts.map((account) => {
+		return {
+			...account,
+			isInvalid: false,
+		};
+	});
+}
+
+function setAccountInvalid(
+	allAccounts: AccountInfo[],
+	accountId: string,
+	isInvalid: boolean
+): AccountInfo[] {
+	let accounts = allAccounts.filter((acc) => acc.id !== accountId);
+	const account = allAccounts.find((acc) => acc.id === accountId);
+	if (account) {
+		accounts = [
+			...accounts,
+			{
+				...account,
+				isInvalid,
+			},
+		];
+	}
+	return accounts;
+}
+
 export function createReducer() {
 	return function (
 		state: AppReduxState | undefined,
@@ -63,7 +91,11 @@ export function createReducer() {
 		}
 		switch (action.type) {
 			case 'SET_TOKEN_INVALID':
-				return { ...state, isTokenInvalid: action.isInvalid };
+				return {
+					...state,
+					isTokenInvalid: action.isInvalid,
+					accounts: setAccountInvalid(state.accounts, action.accountId, true),
+				};
 			case 'TOGGLE_LOGGING':
 				return { ...state, isLogging: action.isLogging };
 			case 'SET_DEMO_MODE':
@@ -120,7 +152,7 @@ export function createReducer() {
 			case 'SET_ACCOUNTS':
 				return {
 					...state,
-					accounts: action.accounts,
+					accounts: setAllAccountsValid(action.accounts),
 				};
 			case 'SELECT_ACCOUNT':
 				return {
@@ -226,9 +258,10 @@ export function setIsDemoMode(isDemoMode: boolean): ActionSetDemoMode {
 }
 
 export function setIsTokenInvalid(
+	accountId: string,
 	isInvalid: boolean
 ): ActionToggleTokenInvalid {
-	return { type: 'SET_TOKEN_INVALID', isInvalid };
+	return { type: 'SET_TOKEN_INVALID', accountId, isInvalid };
 }
 
 export function changeToOffline(): ActionChangeToOffline {

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -26,6 +26,7 @@ import {
 	ActionToggleTokenInvalid,
 	AccountInfo,
 	ActionSelectAccount,
+	ActionInitSetAccounts,
 } from '../types';
 
 const defaultFetchInterval = secsToMs(120);
@@ -115,6 +116,7 @@ export function createReducer() {
 					);
 				return Object.assign({}, state, { notes });
 			}
+			case 'SET_INITIAL_ACCOUNTS':
 			case 'SET_ACCOUNTS':
 				return {
 					...state,
@@ -209,6 +211,10 @@ export function markAllNotesSeen(): ActionMarkAllNotesSeen {
 
 export function initToken(token: string): ActionInitToken {
 	return { type: 'SET_INITIAL_TOKEN', token };
+}
+
+export function initAccounts(accounts: AccountInfo[]): ActionInitSetAccounts {
+	return { type: 'SET_INITIAL_ACCOUNTS', accounts };
 }
 
 export function selectAccount(account: AccountInfo): ActionSelectAccount {

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -48,6 +48,10 @@ export type ActionSelectAccount = {
 	type: 'SELECT_ACCOUNT';
 	account: AccountInfo;
 };
+export type ActionInitSetAccounts = {
+	type: 'SET_INITIAL_ACCOUNTS';
+	accounts: AccountInfo[];
+};
 export type ActionSetAccounts = {
 	type: 'SET_ACCOUNTS';
 	accounts: AccountInfo[];
@@ -89,6 +93,7 @@ export type MarkAppShown = { type: 'NOTE_APP_VISIBLE'; visible: true };
 export type ActionSetDemoMode = { type: 'SET_DEMO_MODE'; isDemoMode: boolean };
 
 export type AppReduxAction =
+	| ActionInitSetAccounts
 	| ActionSelectAccount
 	| ActionMuteRepo
 	| ActionUnmuteRepo
@@ -152,6 +157,8 @@ export interface MainBridge {
 	markNotificationRead: (note: Note, account: AccountInfo) => void;
 	isDemoMode: () => Promise<boolean>;
 	isAutoLaunchEnabled: () => Promise<boolean>;
+	saveAccounts: (accounts: AccountInfo[]) => void;
+	getAccounts: () => Promise<AccountInfo[]>;
 }
 
 export interface FetchErrorObject {

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -5,9 +5,14 @@ import {
 	PANE_ACCOUNTS,
 	PANE_ACCOUNT_EDIT,
 } from './lib/constants';
-import type { NoteReason, Note, AccountInfo } from '../shared-types';
+import type {
+	NoteReason,
+	Note,
+	AccountInfo,
+	FetchErrorObject,
+} from '../shared-types';
 
-export type { NoteReason, Note, AccountInfo };
+export type { NoteReason, Note, AccountInfo, FetchErrorObject };
 
 export type FilterType = NoteReason | 'all';
 
@@ -58,6 +63,7 @@ export type ActionSetAccounts = {
 };
 export type ActionToggleTokenInvalid = {
 	type: 'SET_TOKEN_INVALID';
+	accountId: string;
 	isInvalid: boolean;
 };
 export type ActionToggleLogging = {
@@ -153,22 +159,14 @@ export interface MainBridge {
 	onClick: (callback: () => void) => void;
 	getToken: () => Promise<string>;
 	getVersion: () => Promise<string>;
-	getNotificationsForAccount: (account: AccountInfo) => Promise<Note[]>;
+	getNotificationsForAccount: (
+		account: AccountInfo
+	) => Promise<Note[] | { error: Error }>;
 	markNotificationRead: (note: Note, account: AccountInfo) => void;
 	isDemoMode: () => Promise<boolean>;
 	isAutoLaunchEnabled: () => Promise<boolean>;
 	saveAccounts: (accounts: AccountInfo[]) => void;
 	getAccounts: () => Promise<AccountInfo[]>;
-}
-
-export interface FetchErrorObject {
-	code?: string;
-	name?: string;
-	message?: string;
-	statusText?: string;
-	status?: number;
-	url?: string;
-	type?: string;
 }
 
 export type UnknownFetchError = FetchErrorObject | string;

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -55,4 +55,16 @@ export interface AccountInfo {
 	apiKey: string;
 	serverUrl: string;
 	proxyUrl?: string;
+	isInvalid?: boolean;
+}
+
+export interface FetchErrorObject {
+	code?: string;
+	name?: string;
+	message?: string;
+	statusText?: string;
+	status?: number;
+	url?: string;
+	type?: string;
+	accountId: string;
 }

--- a/tests/gitnews-fetcher.js
+++ b/tests/gitnews-fetcher.js
@@ -18,13 +18,6 @@ window.electronApi = {
 };
 
 describe('handleFetchError()', function () {
-	it('does nothing if the error is GitHubTokenNotFound', function () {
-		const dispatch = jest.fn();
-		const handleFetchError = getErrorHandler(dispatch);
-		handleFetchError({ code: 'GitHubTokenNotFound' });
-		expect(dispatch).not.toHaveBeenCalled();
-	});
-
 	it('enables offline mode if error is ENETDOWN', function () {
 		const dispatch = jest.fn();
 		const handleFetchError = getErrorHandler(dispatch);


### PR DESCRIPTION
This is a follow-up to https://github.com/sirbrillig/gitnews-menubar/pull/187 which fixes and cleans up some things to improve the experience with accounts.

- Persist accounts across apps (allows for upgrades).
- Properly parse errors when fetching fails to show reason.
- Fix immediate fetch when accounts change.