### PR TITLE
Fetch unread notifications in addition to read ones

### DIFF
--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -101,6 +101,68 @@ export async function markNotficationAsRead(
 	}
 }
 
+async function getCommentDataForNotification(
+	octokit: Octokit,
+	account: AccountInfo,
+	notification: { subject: { latest_comment_url?: string; url: string } }
+): Promise<{
+	commentAvatar: string;
+	commentHtmlUrl: string;
+}> {
+	let commentAvatar: string = '';
+	let commentHtmlUrl: string = '';
+	const commentPath = getOctokitRequestPathFromUrl(
+		account,
+		notification.subject.latest_comment_url ?? notification.subject.url
+	);
+	try {
+		const comment = await octokit.request(`GET ${commentPath}`, {});
+		commentAvatar = comment.data.user.avatar_url;
+		commentHtmlUrl = comment.data.html_url;
+	} catch (error) {
+		logMessage(
+			`Failed to fetch comment for ${commentPath} (${notification.subject.latest_comment_url ?? notification.subject.url})`,
+			'error'
+		);
+	}
+	return {
+		commentAvatar,
+		commentHtmlUrl,
+	};
+}
+
+async function getSubjectDataForNotification(
+	octokit: Octokit,
+	account: AccountInfo,
+	notification: {
+		subject: { url: string };
+	}
+) {
+	let noteState: string = '';
+	let noteMerged: boolean = false;
+	let subjectHtmlUrl: string = '';
+	const subjectPath = getOctokitRequestPathFromUrl(
+		account,
+		notification.subject.url
+	);
+	try {
+		const subject = await octokit.request(`GET ${subjectPath}`, {});
+		noteState = subject.data.state;
+		noteMerged = subject.data.merged;
+		subjectHtmlUrl = subject.data.html_url;
+	} catch (error) {
+		logMessage(
+			`Failed to fetch comment for ${subjectPath} (${notification.subject.url})`,
+			'error'
+		);
+	}
+	return {
+		noteState,
+		noteMerged,
+		subjectHtmlUrl,
+	};
+}
+
 export async function fetchNotificationsForAccount(
 	account: AccountInfo
 ): Promise<Note[]> {
@@ -114,43 +176,11 @@ export async function fetchNotificationsForAccount(
 
 	// FIXME: do these fetches in parallel instead of serial
 	for (const notification of notificationsResponse.data) {
-		let commentAvatar: string;
-		let commentHtmlUrl: string;
-		const commentPath = getOctokitRequestPathFromUrl(
-			account,
-			notification.subject.latest_comment_url ?? notification.subject.url
-		);
-		try {
-			const comment = await octokit.request(`GET ${commentPath}`, {});
-			commentAvatar = comment.data.user.avatar_url;
-			commentHtmlUrl = comment.data.html_url;
-		} catch (error) {
-			logMessage(
-				`Failed to fetch comment for ${commentPath} (${notification.subject.latest_comment_url ?? notification.subject.url})`,
-				'error'
-			);
-			continue;
-		}
+		const { commentAvatar, commentHtmlUrl } =
+			await getCommentDataForNotification(octokit, account, notification);
 
-		let noteState: string;
-		let noteMerged: boolean;
-		let subjectHtmlUrl: string;
-		const subjectPath = getOctokitRequestPathFromUrl(
-			account,
-			notification.subject.url
-		);
-		try {
-			const subject = await octokit.request(`GET ${subjectPath}`, {});
-			noteState = subject.data.state;
-			noteMerged = subject.data.merged;
-			subjectHtmlUrl = subject.data.html_url;
-		} catch (error) {
-			logMessage(
-				`Failed to fetch comment for ${subjectPath} (${notification.subject.url})`,
-				'error'
-			);
-			continue;
-		}
+		const { noteState, noteMerged, subjectHtmlUrl } =
+			await getSubjectDataForNotification(octokit, account, notification);
 
 		notes.push({
 			gitnewsAccountId: account.id,

--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -107,11 +107,12 @@ export async function fetchNotificationsForAccount(
 	const octokit = createOctokit(account);
 	const notificationsResponse =
 		await octokit.rest.activity.listNotificationsForAuthenticatedUser({
-			all: false,
+			all: true,
 		});
 
 	const notes: Note[] = [];
 
+	// FIXME: do these fetches in parallel instead of serial
 	for (const notification of notificationsResponse.data) {
 		let commentAvatar: string;
 		let commentHtmlUrl: string;

--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -101,14 +101,37 @@ export async function markNotficationAsRead(
 	}
 }
 
+interface RawNotification {
+	id: string;
+	url: string;
+	subject: {
+		title: string;
+		type: string;
+		latest_comment_url: string;
+		url: string;
+	};
+	unread: boolean;
+	reason: string;
+	repository: {
+		full_name: string;
+		name: string;
+		owner: {
+			avatar_url: string;
+		};
+	};
+	updated_at: string;
+}
+
+interface CommentData {
+	commentAvatar: string;
+	commentHtmlUrl: string;
+}
+
 async function getCommentDataForNotification(
 	octokit: Octokit,
 	account: AccountInfo,
-	notification: { subject: { latest_comment_url?: string; url: string } }
-): Promise<{
-	commentAvatar: string;
-	commentHtmlUrl: string;
-}> {
+	notification: RawNotification
+): Promise<CommentData> {
 	let commentAvatar: string = '';
 	let commentHtmlUrl: string = '';
 	const commentPath = getOctokitRequestPathFromUrl(
@@ -131,13 +154,17 @@ async function getCommentDataForNotification(
 	};
 }
 
+interface SubjectData {
+	noteState: string;
+	noteMerged: boolean;
+	subjectHtmlUrl: string;
+}
+
 async function getSubjectDataForNotification(
 	octokit: Octokit,
 	account: AccountInfo,
-	notification: {
-		subject: { url: string };
-	}
-) {
+	notification: RawNotification
+): Promise<SubjectData> {
 	let noteState: string = '';
 	let noteMerged: boolean = false;
 	let subjectHtmlUrl: string = '';
@@ -163,6 +190,39 @@ async function getSubjectDataForNotification(
 	};
 }
 
+function buildNoteFromData({
+	account,
+	notification,
+	commentData,
+	subjectData,
+}: {
+	account: AccountInfo;
+	notification: RawNotification;
+	commentData: CommentData;
+	subjectData: SubjectData;
+}): Note {
+	return {
+		gitnewsAccountId: account.id,
+		id: notification.id,
+		url: notification.url,
+		title: notification.subject.title,
+		unread: notification.unread,
+		repositoryFullName: notification.repository.full_name,
+		commentUrl: commentData.commentHtmlUrl,
+		updatedAt: notification.updated_at,
+		repositoryName: notification.repository.name,
+		type: notification.subject.type,
+		subjectUrl: subjectData.subjectHtmlUrl,
+		commentAvatar:
+			commentData.commentAvatar ?? notification.repository.owner.avatar_url,
+		repositoryOwnerAvatar: notification.repository.owner.avatar_url,
+		api: {
+			subject: { state: subjectData.noteState, merged: subjectData.noteMerged },
+			notification: { reason: notification.reason as NoteReason },
+		},
+	};
+}
+
 export async function fetchNotificationsForAccount(
 	account: AccountInfo
 ): Promise<Note[]> {
@@ -176,31 +236,24 @@ export async function fetchNotificationsForAccount(
 
 	// FIXME: do these fetches in parallel instead of serial
 	for (const notification of notificationsResponse.data) {
-		const { commentAvatar, commentHtmlUrl } =
-			await getCommentDataForNotification(octokit, account, notification);
-
-		const { noteState, noteMerged, subjectHtmlUrl } =
-			await getSubjectDataForNotification(octokit, account, notification);
-
-		notes.push({
-			gitnewsAccountId: account.id,
-			id: notification.id,
-			url: notification.url,
-			title: notification.subject.title,
-			unread: notification.unread,
-			repositoryFullName: notification.repository.full_name,
-			commentUrl: commentHtmlUrl,
-			updatedAt: notification.updated_at,
-			repositoryName: notification.repository.name,
-			type: notification.subject.type,
-			subjectUrl: subjectHtmlUrl,
-			commentAvatar: commentAvatar ?? notification.repository.owner.avatar_url,
-			repositoryOwnerAvatar: notification.repository.owner.avatar_url,
-			api: {
-				subject: { state: noteState, merged: noteMerged },
-				notification: { reason: notification.reason as NoteReason },
-			},
-		});
+		const commentData = await getCommentDataForNotification(
+			octokit,
+			account,
+			notification
+		);
+		const subjectData = await getSubjectDataForNotification(
+			octokit,
+			account,
+			notification
+		);
+		notes.push(
+			buildNoteFromData({
+				account,
+				notification,
+				subjectData,
+				commentData,
+			})
+		);
 	}
 
 	return notes;

--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -234,27 +234,39 @@ export async function fetchNotificationsForAccount(
 
 	const notes: Note[] = [];
 
-	// FIXME: do these fetches in parallel instead of serial
+	// We need to make more requests to get the details of each notification. Do
+	// these fetches in parallel.
+	let promises = [];
 	for (const notification of notificationsResponse.data) {
-		const commentData = await getCommentDataForNotification(
+		logMessage(
+			`Fetching additional details for notification ${notification.id}`,
+			'info'
+		);
+		const commentPromise = getCommentDataForNotification(
 			octokit,
 			account,
 			notification
 		);
-		const subjectData = await getSubjectDataForNotification(
+		const subjectPromise = getSubjectDataForNotification(
 			octokit,
 			account,
 			notification
 		);
-		notes.push(
-			buildNoteFromData({
-				account,
-				notification,
-				subjectData,
-				commentData,
-			})
-		);
+		const promise = Promise.all([commentPromise, subjectPromise]);
+		promises.push(promise);
+		promise.then(([commentData, subjectData]) => {
+			notes.push(
+				buildNoteFromData({
+					account,
+					notification,
+					subjectData,
+					commentData,
+				})
+			);
+		});
 	}
+
+	await Promise.all(promises);
 
 	return notes;
 }

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -144,17 +144,27 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 		}
 		return async () => {
 			let allNotes: Note[] = [];
+
+			const promises = [];
+
+			// Do the fetching in parallel.
 			for (const account of accounts) {
 				window.electronApi.logMessage(
 					`Fetching notifications for ${account.name} (${account.serverUrl})`,
 					'info'
 				);
-				const notes = await fetchNotifications(account);
-				if ('error' in notes) {
-					throw notes.error;
-				}
-				allNotes = [...allNotes, ...notes];
+				const promise = fetchNotifications(account);
+				promises.push(promise);
+				promise.then((notes) => {
+					if ('error' in notes) {
+						throw notes.error;
+					}
+					allNotes = [...allNotes, ...notes];
+				});
 			}
+
+			await Promise.all(promises);
+
 			allNotes.sort((a, b) => {
 				if (a.updatedAt < b.updatedAt) {
 					return 1;

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -70,6 +70,7 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 				return next(action);
 			}
 
+			// FIXME: why does this trigger so many times during a fetch?
 			if (action.type === 'GITNEWS_FETCH_NOTIFICATIONS') {
 				debug('Fetching accounts');
 				window.electronApi.logMessage('Fetching accounts', 'info');
@@ -144,6 +145,10 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 		return async () => {
 			let allNotes: Note[] = [];
 			for (const account of accounts) {
+				window.electronApi.logMessage(
+					`Fetching notifications for ${account.name} (${account.serverUrl})`,
+					'info'
+				);
 				const notes = await fetchNotifications(account);
 				if ('error' in notes) {
 					throw notes.error;

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -22,6 +22,14 @@ function getMatchingPrevNote(prevNotes: Note[], note: Note): Note | undefined {
 	return prevNotes.find((prevNote) => getNoteId(prevNote) === getNoteId(note));
 }
 
+/**
+ * Return all the new notes, but if they match one of the previous notes,
+ * update the new note's "seen" and "unread" properties to match those of the
+ * previous note.
+ *
+ * This allows updated unread notes which have been "seen" to retain that
+ * property if the user has already seen them.
+ */
 export function mergeNotifications(
 	prevNotes: Note[],
 	nextNotes: Note[]

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -7,26 +7,33 @@ export function getNoteId(note: Note) {
 	return note.id;
 }
 
+function hasNoteUpdated(note: Note, prevNote: Note): boolean {
+	if (
+		note.updatedAt &&
+		prevNote.gitnewsSeenAt &&
+		Date.parse(note.updatedAt) > prevNote.gitnewsSeenAt
+	) {
+		return true;
+	}
+	return false;
+}
+
+function getMatchingPrevNote(prevNotes: Note[], note: Note): Note | undefined {
+	return prevNotes.find((prevNote) => getNoteId(prevNote) === getNoteId(note));
+}
+
 export function mergeNotifications(
 	prevNotes: Note[],
 	nextNotes: Note[]
 ): Note[] {
-	const getMatchingPrevNote = (note: Note) =>
-		prevNotes.find((prevNote) => getNoteId(prevNote) === getNoteId(note));
-	const hasNoteUpdated = (note: Note, prevNote: Note) =>
-		Boolean(
-			note.updatedAt &&
-				prevNote.gitnewsSeenAt &&
-				Date.parse(note.updatedAt) > prevNote.gitnewsSeenAt
-		);
-
 	return nextNotes.map((note) => {
-		const previousNote = getMatchingPrevNote(note);
+		const previousNote = getMatchingPrevNote(prevNotes, note);
 		if (previousNote && !hasNoteUpdated(note, previousNote)) {
-			return Object.assign({}, note, {
+			return {
+				...note,
 				gitnewsSeen: previousNote.gitnewsSeen,
 				gitnewsMarkedUnread: previousNote.gitnewsMarkedUnread,
-			});
+			};
 		}
 		return note;
 	});


### PR DESCRIPTION
This fixes a regression introduced by #187 where we stopped showing previously-read notes.

Fixes #193 