### PR TITLE
Add basic validation of github API responses

### DIFF
--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -223,6 +223,20 @@ function buildNoteFromData({
 	};
 }
 
+function isGithubActivityResponseValid(
+	response: RestEndpointMethodTypes['activity']['listNotificationsForAuthenticatedUser']['response']
+): boolean {
+	if (!Array.isArray(response?.data)) {
+		return false;
+	}
+	for (const notification of response.data) {
+		if (!notification.id || !notification.subject) {
+			return false;
+		}
+	}
+	return true;
+}
+
 export async function fetchNotificationsForAccount(
 	account: AccountInfo
 ): Promise<Note[]> {
@@ -231,6 +245,16 @@ export async function fetchNotificationsForAccount(
 		await octokit.rest.activity.listNotificationsForAuthenticatedUser({
 			all: true,
 		});
+
+	if (!isGithubActivityResponseValid(notificationsResponse)) {
+		logMessage(
+			`Raw notification data from account ${account.name} (${account.id}) is invalid: ${JSON.stringify(notificationsResponse)}`,
+			'error'
+		);
+		throw new Error(
+			`Raw notification data fetched from account ${account.name} (${account.id}) is invalid. Please make sure your server is active and operating correctly (eg: it may be in maintenance).`
+		);
+	}
 
 	const notes: Note[] = [];
 

--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -1,5 +1,5 @@
 import type { AccountInfo, Note, NoteReason } from '../../shared-types';
-import { Octokit } from '@octokit/rest';
+import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { fetch as undiciFetch, ProxyAgent } from 'undici';
 import { socksDispatcher } from 'fetch-socks';
 import { logMessage } from './logging';


### PR DESCRIPTION
I assumed that octokit would do at least basic validation of the data it gets back from the Github server, but apparently it does not. Sometimes the data it returns will not match its TypeScript types and might instead be, for example, HTML that says something like `There was an issue connecting to your enterprise instance. Check your network and whether the instance is online and try to reload this page.`

In this PR we add some basic validation that the data we get from the Github server is what it claims to be.

Fixes https://github.com/sirbrillig/gitnews-menubar/issues/198

Before             |  After
:-------------------------:|:-------------------------:
<img width="806" alt="Screenshot 2024-11-16 at 11 55 02 AM" src="https://github.com/user-attachments/assets/23366fed-d902-4be4-8a16-7d0e0470b2a2"> | <img width="391" alt="Screenshot 2024-11-16 at 1 50 20 PM" src="https://github.com/user-attachments/assets/35dd672d-4228-4e3c-a82a-d670b9dde22b">
