### PR TITLE
Fix note ID calculation

### DIFF
--- a/src/renderer/components/notifications-area.tsx
+++ b/src/renderer/components/notifications-area.tsx
@@ -181,7 +181,7 @@ function doesNoteMatchSearch(note: Note, searchValue: string) {
 }
 
 function isNoteInNotes(note: Note, notes: Note[]) {
-	return notes.some((item) => item.id === note.id);
+	return notes.some((item) => getNoteId(item) === getNoteId(note));
 }
 
 function MultiOpenNotice() {

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -132,11 +132,11 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 			return;
 		}
 		debug('fetching notifications in middleware');
-		// NOTE: After this point, any return action MUST disable fetchingInProgress
-		// or the app will get stuck never updating again.
-		next(fetchBegin());
 
 		try {
+			// NOTE: After this point, any return action MUST disable fetchingInProgress
+			// or the app will get stuck never updating again.
+			next(fetchBegin());
 			const getGithubNotifications = getFetcher(
 				state.accounts,
 				state.isDemoMode
@@ -147,7 +147,6 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 				`Notifications retrieved (${notes.length} found in ${state.accounts.length} accounts)`,
 				'info'
 			);
-			next(fetchDone());
 			next(gotNotes(notes));
 		} catch (err) {
 			debug('Fetching notifications threw an error', err);
@@ -155,8 +154,9 @@ export function createFetcher(): Middleware<{}, AppReduxState> {
 				`Fetching notifications threw an error`,
 				'warn'
 			);
-			next(fetchDone());
 			getErrorHandler(next)(err as FetchErrorObject);
+		} finally {
+			next(fetchDone());
 		}
 	}
 

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -29,6 +29,10 @@ function getMatchingPrevNote(prevNotes: Note[], note: Note): Note | undefined {
  *
  * This allows updated unread notes which have been "seen" to retain that
  * property if the user has already seen them.
+ *
+ * Note that if a previous note is not in the new notes, it will not be
+ * returned. To put it another way: we only return new notes and throw away all
+ * old notes.
  */
 export function mergeNotifications(
 	prevNotes: Note[],
@@ -36,6 +40,9 @@ export function mergeNotifications(
 ): Note[] {
 	return nextNotes.map((note) => {
 		const previousNote = getMatchingPrevNote(prevNotes, note);
+		// If the note already existed and has not changed, replace all its
+		// properties but preserve the special gitnews properties so "seen" or
+		// "marked unread" notes stay "seen" or "unread".
 		if (previousNote && !hasNoteUpdated(note, previousNote)) {
 			return {
 				...note,

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -4,7 +4,7 @@ import { AppDispatch } from './store';
 const maxFetchInterval = secsToMs(300); // 5 minutes
 
 export function getNoteId(note: Note) {
-	return note.id;
+	return 'gh_acc:' + note.gitnewsAccountId + '-__-gh_id:' + note.id;
 }
 
 function hasNoteUpdated(note: Note, prevNote: Note): boolean {

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -190,7 +190,7 @@ export function createReducer() {
 					fetchRetryCount: 0,
 					errors: [],
 					fetchInterval: defaultFetchInterval,
-					notes: mergeNotifications(state.notes, action.notes),
+					notes: newNotes,
 				});
 			}
 			case 'CHANGE_AUTO_LOAD':


### PR DESCRIPTION
This makes sure to include account ID in note ID and to always use the note ID properly for comparisons.

- **Fix getNoteId to include account ID**
- **Fix isNoteInNotes to use getNoteId**
- **Move fetchDone action to finally block**
- **No need to merge notes twice**
