### PR TITLE
Use big "Mark as read/unread" button for notes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,8 +51,8 @@ const bar = menubar({
 	index: MAIN_WINDOW_WEBPACK_ENTRY,
 	icon: getIconForState('loading'),
 	browserWindow: {
-		width: 390,
-		height: 500,
+		width: 430,
+		height: 600,
 		webPreferences: {
 			nodeIntegration: true,
 			preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -10,6 +10,7 @@ import {
 	MarkUnread,
 	MuteRepo,
 	UnmuteRepo,
+	QueuedAction,
 } from '../types';
 import { ImageWithBackup } from './image-with-backup';
 
@@ -27,12 +28,8 @@ export default function Notification({
 	isMuteRequested,
 	setMuteRequested,
 	isMultiOpenMode,
-	isMultiOpenPending,
-	saveNoteToOpen,
-	saveNoteToMarkRead,
-	isMultiMarkReadPending,
-	saveNoteToMarkUnread,
-	isMultiMarkUnreadPending,
+	queueNoteAction,
+	queuedAction,
 }: {
 	note: Note;
 	openUrl: OpenUrl;
@@ -45,12 +42,8 @@ export default function Notification({
 	isMuteRequested: boolean;
 	setMuteRequested: (n: Note | false) => void;
 	isMultiOpenMode: boolean;
-	isMultiOpenPending: boolean;
-	saveNoteToOpen: (n: Note) => void;
-	saveNoteToMarkRead: (n: Note) => void;
-	isMultiMarkReadPending: boolean;
-	saveNoteToMarkUnread: (n: Note) => void;
-	isMultiMarkUnreadPending: boolean;
+	queueNoteAction: (note: Note, action: QueuedAction) => void;
+	queuedAction?: QueuedAction;
 }) {
 	const isUnread =
 		note.unread === true ? true : note.gitnewsMarkedUnread === true;
@@ -59,7 +52,7 @@ export default function Notification({
 		debug('clicked on notification', note);
 		setMuteRequested(false);
 		if (isMultiOpenMode) {
-			saveNoteToOpen(note);
+			queueNoteAction(note, 'open');
 			return;
 		}
 		markRead(token, note);
@@ -72,7 +65,7 @@ export default function Notification({
 		debug('clicked mark-as-read button', note);
 		setMuteRequested(false);
 		if (isMultiOpenMode) {
-			saveNoteToMarkRead(note);
+			queueNoteAction(note, 'markRead');
 			return;
 		}
 		markRead(token, note);
@@ -84,7 +77,7 @@ export default function Notification({
 		debug('clicked mark-as-unread button', note);
 		setMuteRequested(false);
 		if (isMultiOpenMode) {
-			saveNoteToMarkUnread(note);
+			queueNoteAction(note, 'markUnread');
 			return;
 		}
 		markUnread(note);
@@ -94,14 +87,12 @@ export default function Notification({
 	const timeString = formatDistanceToNow(lastUpdated, { addSuffix: true });
 	const noteClasses = [
 		'notification',
-		...(isMultiOpenMode && !isMultiOpenPending && !isMultiMarkReadPending && !isMultiMarkUnreadPending
-			? ['notification--multi-open']
-			: []),
-		...(isMultiOpenPending ? ['notification--multi-open-clicked'] : []),
-		...(isMultiMarkReadPending
+		...(isMultiOpenMode && !queuedAction ? ['notification--multi-open'] : []),
+		...(queuedAction === 'open' ? ['notification--multi-open-clicked'] : []),
+		...(queuedAction === 'markRead'
 			? ['notification--multi-mark-read-clicked']
 			: []),
-		...(isMultiMarkUnreadPending
+		...(queuedAction === 'markUnread'
 			? ['notification--multi-mark-unread-clicked']
 			: []),
 		...getNoteClasses({ isUnread, isMuted }),
@@ -164,11 +155,11 @@ export default function Notification({
 
 	return (
 		<div className={noteClasses.join(' ')}>
-			{isMultiOpenPending && <MultiOpenPendingNotice onClick={onClick} />}
-			{isMultiMarkReadPending && (
+			{queuedAction === 'open' && <MultiOpenPendingNotice onClick={onClick} />}
+			{queuedAction === 'markRead' && (
 				<MultiMarkReadPendingNotice onClick={onClickMarkRead} />
 			)}
-			{isMultiMarkUnreadPending && (
+			{queuedAction === 'markUnread' && (
 				<MultiMarkUnreadPendingNotice onClick={onClickMarkUnread} />
 			)}
 			<div className="notification__main-content" onClick={onClick}>

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -74,6 +74,14 @@ export default function Notification({
 		markRead(token, note);
 	};
 
+	const onClickMarkUnread = (event: React.MouseEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		event.stopPropagation();
+		debug('clicked mark-as-unread button', note);
+		setMuteRequested(false);
+		markUnread(note);
+	};
+
 	const lastUpdated = new Date(note.updatedAt);
 	const timeString = formatDistanceToNow(lastUpdated, { addSuffix: true });
 	const noteClasses = [
@@ -180,33 +188,17 @@ export default function Notification({
 									onClick={doMute}
 								/>
 							)}
-							{isUnread ? (
-								<MarkReadButton
-									disabled={isMultiOpenMode}
-									note={note}
-									token={token}
-									markRead={markRead}
-								/>
-							) : (
-								<MarkUnreadButton
-									disabled={isMultiOpenMode}
-									note={note}
-									markUnread={markUnread}
-								/>
-							)}
 						</span>
 					</div>
 				</div>
 			</div>
-			{isUnread && isMultiOpenMode && (
-				<div
-					className="notification__mark-read-target"
-					onClick={onClickMarkRead}
-					title="Mark as read"
-				>
-					<Gridicon icon="checkmark" size={18} />
-				</div>
-			)}
+			<div
+				className="notification__mark-read-target"
+				onClick={isUnread ? onClickMarkRead : onClickMarkUnread}
+				title={isUnread ? 'Mark as read' : 'Mark as unread'}
+			>
+				<Gridicon icon={isUnread ? 'checkmark' : 'mail'} size={18} />
+			</div>
 		</div>
 	);
 }
@@ -289,68 +281,6 @@ function UnmuteRepoButton({
 			disabled={disabled}
 		>
 			unmute repo
-		</button>
-	);
-}
-
-function MarkReadButton({
-	note,
-	token,
-	markRead,
-	disabled,
-}: {
-	note: Note;
-	token: string;
-	markRead: MarkRead;
-	disabled?: boolean;
-}) {
-	const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-		event.preventDefault();
-		event.stopPropagation();
-		debug('clicked to mark notification as read', note);
-		markRead(token, note);
-	};
-	if (disabled) {
-		return null;
-	}
-	return (
-		<button
-			className="notification__mark-read"
-			onClick={onClick}
-			aria-label="Mark notification as read"
-			disabled={disabled}
-		>
-			mark read
-		</button>
-	);
-}
-
-function MarkUnreadButton({
-	note,
-	markUnread,
-	disabled,
-}: {
-	note: Note;
-	markUnread: MarkUnread;
-	disabled?: boolean;
-}) {
-	const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-		event.preventDefault();
-		event.stopPropagation();
-		debug('clicked to mark notification as unread', note);
-		markUnread(note);
-	};
-	if (disabled) {
-		return null;
-	}
-	return (
-		<button
-			className="notification__mark-unread"
-			onClick={onClick}
-			aria-label="Mark as unread"
-			disabled={disabled}
-		>
-			mark unread
 		</button>
 	);
 }

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -31,6 +31,8 @@ export default function Notification({
 	saveNoteToOpen,
 	saveNoteToMarkRead,
 	isMultiMarkReadPending,
+	saveNoteToMarkUnread,
+	isMultiMarkUnreadPending,
 }: {
 	note: Note;
 	openUrl: OpenUrl;
@@ -47,6 +49,8 @@ export default function Notification({
 	saveNoteToOpen: (n: Note) => void;
 	saveNoteToMarkRead: (n: Note) => void;
 	isMultiMarkReadPending: boolean;
+	saveNoteToMarkUnread: (n: Note) => void;
+	isMultiMarkUnreadPending: boolean;
 }) {
 	const isUnread =
 		note.unread === true ? true : note.gitnewsMarkedUnread === true;
@@ -79,6 +83,10 @@ export default function Notification({
 		event.stopPropagation();
 		debug('clicked mark-as-unread button', note);
 		setMuteRequested(false);
+		if (isMultiOpenMode) {
+			saveNoteToMarkUnread(note);
+			return;
+		}
 		markUnread(note);
 	};
 
@@ -86,12 +94,15 @@ export default function Notification({
 	const timeString = formatDistanceToNow(lastUpdated, { addSuffix: true });
 	const noteClasses = [
 		'notification',
-		...(isMultiOpenMode && !isMultiOpenPending && !isMultiMarkReadPending
+		...(isMultiOpenMode && !isMultiOpenPending && !isMultiMarkReadPending && !isMultiMarkUnreadPending
 			? ['notification--multi-open']
 			: []),
 		...(isMultiOpenPending ? ['notification--multi-open-clicked'] : []),
 		...(isMultiMarkReadPending
 			? ['notification--multi-mark-read-clicked']
+			: []),
+		...(isMultiMarkUnreadPending
+			? ['notification--multi-mark-unread-clicked']
 			: []),
 		...getNoteClasses({ isUnread, isMuted }),
 	];
@@ -156,6 +167,9 @@ export default function Notification({
 			{isMultiOpenPending && <MultiOpenPendingNotice onClick={onClick} />}
 			{isMultiMarkReadPending && (
 				<MultiMarkReadPendingNotice onClick={onClickMarkRead} />
+			)}
+			{isMultiMarkUnreadPending && (
+				<MultiMarkUnreadPendingNotice onClick={onClickMarkUnread} />
 			)}
 			<div className="notification__main-content" onClick={onClick}>
 				<div className={iconClasses.join(' ')}>
@@ -324,6 +338,22 @@ function MultiMarkReadPendingNotice({
 				✓
 			</span>
 			<div>Release Command key to mark as read</div>
+			<div>(click to deselect)</div>
+		</div>
+	);
+}
+
+function MultiMarkUnreadPendingNotice({
+	onClick,
+}: {
+	onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+}) {
+	return (
+		<div className="multi-open-pending-notice" onClick={onClick}>
+			<span className="multi-open-pending-notice__icon multi-open-pending-notice--mark-unread">
+				✉
+			</span>
+			<div>Release Command key to mark as unread</div>
 			<div>(click to deselect)</div>
 		</div>
 	);

--- a/src/renderer/components/notifications-area.tsx
+++ b/src/renderer/components/notifications-area.tsx
@@ -13,6 +13,7 @@ import {
 	Note,
 	OpenUrl,
 	UnmuteRepo,
+	QueuedAction,
 } from '../types';
 
 const debug = debugFactory('gitnews-menubar');
@@ -71,105 +72,48 @@ export default function NotificationsArea({
 }) {
 	const { isUpdateAvailable, updateUrl, updatedVersion } =
 		useGetGitnewsUpdate();
-	const [notesToOpen, setNotesToOpen] = React.useState<Note[]>([]);
-	const [notesToMarkRead, setNotesToMarkRead] = React.useState<Note[]>([]);
-	const [notesToMarkUnread, setNotesToMarkUnread] = React.useState<Note[]>([]);
-	const saveNoteToOpen = (note: Note) => {
-		// If already in either queue, remove it
-		if (isNoteInNotes(note, notesToOpen)) {
-			setNotesToOpen((notes) =>
-				notes.filter((noteToOpen) => noteToOpen !== note)
-			);
-			return;
-		}
-		if (isNoteInNotes(note, notesToMarkRead)) {
-			setNotesToMarkRead((notes) =>
-				notes.filter((noteToMarkRead) => noteToMarkRead !== note)
-			);
-			return;
-		}
-		if (isNoteInNotes(note, notesToMarkUnread)) {
-			setNotesToMarkUnread((notes) =>
-				notes.filter((noteToMarkUnread) => noteToMarkUnread !== note)
-			);
-			return;
-		}
-		// Not in any queue, add to open queue
-		setNotesToOpen((notes) => [...notes, note]);
+
+	type QueuedNote = { note: Note; action: QueuedAction };
+	const [queuedNotes, setQueuedNotes] = React.useState<Map<string, QueuedNote>>(
+		new Map()
+	);
+
+	const queueNoteAction = (note: Note, action: QueuedAction) => {
+		const noteId = getNoteId(note);
+		setQueuedNotes((queue) => {
+			const newQueue = new Map(queue);
+			const existing = newQueue.get(noteId);
+			// If note is already queued with the same action, remove it (toggle off)
+			if (existing && existing.action === action) {
+				newQueue.delete(noteId);
+			} else {
+				// Otherwise, set or update the action for this note
+				newQueue.set(noteId, { note, action });
+			}
+			return newQueue;
+		});
 	};
 
-	const saveNoteToMarkRead = (note: Note) => {
-		// If already in either queue, remove it
-		if (isNoteInNotes(note, notesToMarkRead)) {
-			setNotesToMarkRead((notes) =>
-				notes.filter((noteToMarkRead) => noteToMarkRead !== note)
-			);
-			return;
-		}
-		if (isNoteInNotes(note, notesToOpen)) {
-			setNotesToOpen((notes) =>
-				notes.filter((noteToOpen) => noteToOpen !== note)
-			);
-			return;
-		}
-		if (isNoteInNotes(note, notesToMarkUnread)) {
-			setNotesToMarkUnread((notes) =>
-				notes.filter((noteToMarkUnread) => noteToMarkUnread !== note)
-			);
-			return;
-		}
-		// Not in any queue, add to mark-read queue
-		setNotesToMarkRead((notes) => [...notes, note]);
-	};
+	const processQueuedNotes = React.useCallback(() => {
+		if (queuedNotes.size === 0) return;
 
-	const saveNoteToMarkUnread = (note: Note) => {
-		// If already in either queue, remove it
-		if (isNoteInNotes(note, notesToMarkUnread)) {
-			setNotesToMarkUnread((notes) =>
-				notes.filter((noteToMarkUnread) => noteToMarkUnread !== note)
-			);
-			return;
-		}
-		if (isNoteInNotes(note, notesToOpen)) {
-			setNotesToOpen((notes) =>
-				notes.filter((noteToOpen) => noteToOpen !== note)
-			);
-			return;
-		}
-		if (isNoteInNotes(note, notesToMarkRead)) {
-			setNotesToMarkRead((notes) =>
-				notes.filter((noteToMarkRead) => noteToMarkRead !== note)
-			);
-			return;
-		}
-		// Not in any queue, add to mark-unread queue
-		setNotesToMarkUnread((notes) => [...notes, note]);
-	};
-
-	const openSavedNotes = React.useCallback(() => {
-		debug('opening notes', notesToOpen);
-		notesToOpen.forEach((note) => {
-			markRead(token, note);
-			openUrl(note.commentUrl);
+		debug('processing queued notes', queuedNotes);
+		queuedNotes.forEach(({ note, action }) => {
+			switch (action) {
+				case 'open':
+					markRead(token, note);
+					openUrl(note.commentUrl);
+					break;
+				case 'markRead':
+					markRead(token, note);
+					break;
+				case 'markUnread':
+					markUnread(note);
+					break;
+			}
 		});
-		setNotesToOpen([]);
-	}, [notesToOpen, openUrl, markRead, token]);
-
-	const markSavedNotesAsRead = React.useCallback(() => {
-		debug('marking notes as read', notesToMarkRead);
-		notesToMarkRead.forEach((note) => {
-			markRead(token, note);
-		});
-		setNotesToMarkRead([]);
-	}, [notesToMarkRead, markRead, token]);
-
-	const markSavedNotesAsUnread = React.useCallback(() => {
-		debug('marking notes as unread', notesToMarkUnread);
-		notesToMarkUnread.forEach((note) => {
-			markUnread(note);
-		});
-		setNotesToMarkUnread([]);
-	}, [notesToMarkUnread, markUnread]);
+		setQueuedNotes(new Map());
+	}, [queuedNotes, openUrl, markRead, markUnread, token]);
 	const onKeyUp = React.useCallback((event: KeyboardEvent) => {
 		debug('Notification keyUp', event.code);
 		if (event.code.includes('Meta')) {
@@ -186,18 +130,10 @@ export default function NotificationsArea({
 	);
 
 	React.useEffect(() => {
-		if (!isMultiOpenMode) {
-			if (notesToOpen.length > 0) {
-				openSavedNotes();
-			}
-			if (notesToMarkRead.length > 0) {
-				markSavedNotesAsRead();
-			}
-			if (notesToMarkUnread.length > 0) {
-				markSavedNotesAsUnread();
-			}
+		if (!isMultiOpenMode && queuedNotes.size > 0) {
+			processQueuedNotes();
 		}
-	}, [isMultiOpenMode, openSavedNotes, notesToOpen, markSavedNotesAsRead, notesToMarkRead, markSavedNotesAsUnread, notesToMarkUnread]);
+	}, [isMultiOpenMode, processQueuedNotes, queuedNotes]);
 
 	React.useEffect(() => {
 		if (!appVisible) {
@@ -224,28 +160,27 @@ export default function NotificationsArea({
 	const orderedNotes = [...newNotes, ...readNotes]
 		.filter((note) => doesNoteMatchSearch(note, searchValue))
 		.filter((note) => doesNoteMatchFilter(note, filterType));
-	const noteRows = orderedNotes.map((note) => (
-		<Notification
-			note={note}
-			key={getNoteId(note)}
-			markRead={markRead}
-			markUnread={markUnread}
-			token={token}
-			openUrl={openUrl}
-			muteRepo={muteRepo}
-			unmuteRepo={unmuteRepo}
-			isMuted={mutedRepos.includes(note.repositoryFullName)}
-			isMuteRequested={muteRequestedFor === note}
-			setMuteRequested={setMuteRequested}
-			isMultiOpenMode={isMultiOpenMode}
-			saveNoteToOpen={saveNoteToOpen}
-			isMultiOpenPending={isNoteInNotes(note, notesToOpen)}
-			saveNoteToMarkRead={saveNoteToMarkRead}
-			isMultiMarkReadPending={isNoteInNotes(note, notesToMarkRead)}
-			saveNoteToMarkUnread={saveNoteToMarkUnread}
-			isMultiMarkUnreadPending={isNoteInNotes(note, notesToMarkUnread)}
-		/>
-	));
+	const noteRows = orderedNotes.map((note) => {
+		const queuedAction = queuedNotes.get(getNoteId(note))?.action;
+		return (
+			<Notification
+				note={note}
+				key={getNoteId(note)}
+				markRead={markRead}
+				markUnread={markUnread}
+				token={token}
+				openUrl={openUrl}
+				muteRepo={muteRepo}
+				unmuteRepo={unmuteRepo}
+				isMuted={mutedRepos.includes(note.repositoryFullName)}
+				isMuteRequested={muteRequestedFor === note}
+				setMuteRequested={setMuteRequested}
+				isMultiOpenMode={isMultiOpenMode}
+				queueNoteAction={queueNoteAction}
+				queuedAction={queuedAction}
+			/>
+		);
+	});
 
 	return (
 		<div className="notifications-area">
@@ -283,7 +218,8 @@ function MultiOpenNotice() {
 	return (
 		<div className="multi-open-notice">
 			<span>
-				Click multiple notifications to open or mark as read, then release the Command key
+				Click multiple notifications to open or mark as read, then release the
+				Command key
 			</span>
 		</div>
 	);

--- a/src/renderer/components/notifications-area.tsx
+++ b/src/renderer/components/notifications-area.tsx
@@ -73,6 +73,7 @@ export default function NotificationsArea({
 		useGetGitnewsUpdate();
 	const [notesToOpen, setNotesToOpen] = React.useState<Note[]>([]);
 	const [notesToMarkRead, setNotesToMarkRead] = React.useState<Note[]>([]);
+	const [notesToMarkUnread, setNotesToMarkUnread] = React.useState<Note[]>([]);
 	const saveNoteToOpen = (note: Note) => {
 		// If already in either queue, remove it
 		if (isNoteInNotes(note, notesToOpen)) {
@@ -84,6 +85,12 @@ export default function NotificationsArea({
 		if (isNoteInNotes(note, notesToMarkRead)) {
 			setNotesToMarkRead((notes) =>
 				notes.filter((noteToMarkRead) => noteToMarkRead !== note)
+			);
+			return;
+		}
+		if (isNoteInNotes(note, notesToMarkUnread)) {
+			setNotesToMarkUnread((notes) =>
+				notes.filter((noteToMarkUnread) => noteToMarkUnread !== note)
 			);
 			return;
 		}
@@ -105,8 +112,38 @@ export default function NotificationsArea({
 			);
 			return;
 		}
+		if (isNoteInNotes(note, notesToMarkUnread)) {
+			setNotesToMarkUnread((notes) =>
+				notes.filter((noteToMarkUnread) => noteToMarkUnread !== note)
+			);
+			return;
+		}
 		// Not in any queue, add to mark-read queue
 		setNotesToMarkRead((notes) => [...notes, note]);
+	};
+
+	const saveNoteToMarkUnread = (note: Note) => {
+		// If already in either queue, remove it
+		if (isNoteInNotes(note, notesToMarkUnread)) {
+			setNotesToMarkUnread((notes) =>
+				notes.filter((noteToMarkUnread) => noteToMarkUnread !== note)
+			);
+			return;
+		}
+		if (isNoteInNotes(note, notesToOpen)) {
+			setNotesToOpen((notes) =>
+				notes.filter((noteToOpen) => noteToOpen !== note)
+			);
+			return;
+		}
+		if (isNoteInNotes(note, notesToMarkRead)) {
+			setNotesToMarkRead((notes) =>
+				notes.filter((noteToMarkRead) => noteToMarkRead !== note)
+			);
+			return;
+		}
+		// Not in any queue, add to mark-unread queue
+		setNotesToMarkUnread((notes) => [...notes, note]);
 	};
 
 	const openSavedNotes = React.useCallback(() => {
@@ -125,6 +162,14 @@ export default function NotificationsArea({
 		});
 		setNotesToMarkRead([]);
 	}, [notesToMarkRead, markRead, token]);
+
+	const markSavedNotesAsUnread = React.useCallback(() => {
+		debug('marking notes as unread', notesToMarkUnread);
+		notesToMarkUnread.forEach((note) => {
+			markUnread(note);
+		});
+		setNotesToMarkUnread([]);
+	}, [notesToMarkUnread, markUnread]);
 	const onKeyUp = React.useCallback((event: KeyboardEvent) => {
 		debug('Notification keyUp', event.code);
 		if (event.code.includes('Meta')) {
@@ -148,8 +193,11 @@ export default function NotificationsArea({
 			if (notesToMarkRead.length > 0) {
 				markSavedNotesAsRead();
 			}
+			if (notesToMarkUnread.length > 0) {
+				markSavedNotesAsUnread();
+			}
 		}
-	}, [isMultiOpenMode, openSavedNotes, notesToOpen, markSavedNotesAsRead, notesToMarkRead]);
+	}, [isMultiOpenMode, openSavedNotes, notesToOpen, markSavedNotesAsRead, notesToMarkRead, markSavedNotesAsUnread, notesToMarkUnread]);
 
 	React.useEffect(() => {
 		if (!appVisible) {
@@ -194,6 +242,8 @@ export default function NotificationsArea({
 			isMultiOpenPending={isNoteInNotes(note, notesToOpen)}
 			saveNoteToMarkRead={saveNoteToMarkRead}
 			isMultiMarkReadPending={isNoteInNotes(note, notesToMarkRead)}
+			saveNoteToMarkUnread={saveNoteToMarkUnread}
+			isMultiMarkUnreadPending={isNoteInNotes(note, notesToMarkUnread)}
 		/>
 	));
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -542,6 +542,8 @@ header h1 {
 
 .notification__title {
 	margin-bottom: 5px;
+	overflow-wrap: break-word;
+	word-break: break-word;
 }
 
 .clear-errors-button {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -389,6 +389,7 @@ header h1 {
 	border-left: 4px solid transparent;
 	position: relative;
 	display: flex;
+	gap: 6px;
 }
 
 .notification--multi-open {

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -140,6 +140,8 @@ export type UnmuteRepo = (repo: string) => void;
 
 export type IconType = 'normal' | 'unseen' | 'unread' | 'offline' | 'error';
 
+export type QueuedAction = 'open' | 'markRead' | 'markUnread';
+
 export type AppPane =
 	| typeof PANE_ACCOUNTS
 	| typeof PANE_ACCOUNT_EDIT


### PR DESCRIPTION
This PR refactors the "Mark as read"/"Mark as unread" buttons to be big icons instead. This way they're easier to click in succession and also entering multi-select mode (by pressing command) does not shift the note layout.