### PR TITLE
Preserve unread from previous note if note is not updated

### DIFF
--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -8,6 +8,16 @@ export function getNoteId(note: Note) {
 }
 
 function hasNoteUpdated(note: Note, prevNote: Note): boolean {
+	// First check if the updatedAt timestamp has changed between fetches
+	if (note.updatedAt && prevNote.updatedAt) {
+		// If timestamps differ, the note was updated on GitHub
+		if (note.updatedAt !== prevNote.updatedAt) {
+			return true;
+		}
+	}
+
+	// Fallback to comparing against gitnewsSeenAt for backwards compatibility
+	// and to handle the "seen" state logic
 	if (!note.updatedAt || !prevNote.gitnewsSeenAt) {
 		return false;
 	}

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -53,6 +53,11 @@ export function mergeNotifications(
 				...note,
 				gitnewsSeen: previousNote.gitnewsSeen,
 				gitnewsMarkedUnread: previousNote.gitnewsMarkedUnread,
+				// Preserve local "mark as read" action if the note hasn't been updated.
+				// This prevents a race condition where marking a note as read locally
+				// gets overwritten by a fetch that completes before the API call to
+				// GitHub finishes.
+				unread: previousNote.unread === false ? false : note.unread,
 			};
 		}
 		return note;

--- a/tests/reducer.js
+++ b/tests/reducer.js
@@ -134,6 +134,7 @@ describe('reducer', function () {
 							id: 'a1',
 							title: 'test note',
 							unread: false,
+							updatedAt: now,
 							gitnewsSeenAt: Date.now(),
 						},
 					],
@@ -141,6 +142,32 @@ describe('reducer', function () {
 				action
 			);
 			expect(result.notes[0].unread).toBe(false);
+		});
+
+		it('does not preserve `unread: false` when notification updatedAt timestamp changes', function () {
+			const olderTime = '2017-08-23T17:20:00Z';
+			const newerTime = '2017-08-23T18:20:00Z';
+			const action = {
+				type: 'NOTES_RETRIEVED',
+				notes: [
+					{ id: 'a1', unread: true, title: 'test note 1', updatedAt: newerTime },
+				],
+			};
+			const result = reducer(
+				{
+					notes: [
+						{
+							id: 'a1',
+							title: 'test note',
+							unread: false,
+							updatedAt: olderTime,
+							gitnewsSeenAt: Date.now(),
+						},
+					],
+				},
+				action
+			);
+			expect(result.notes[0].unread).toBe(true);
 		});
 
 		it('replaces `seen` state for existing notifications with updates', function () {

--- a/tests/reducer.js
+++ b/tests/reducer.js
@@ -125,6 +125,24 @@ describe('reducer', function () {
 			expect(result.notes.filter((note) => note.gitnewsSeen)).toHaveLength(1);
 		});
 
+		it('preserves `unread: false` state when notification was marked as read locally', function () {
+			const action = { type: 'NOTES_RETRIEVED', notes };
+			const result = reducer(
+				{
+					notes: [
+						{
+							id: 'a1',
+							title: 'test note',
+							unread: false,
+							gitnewsSeenAt: Date.now(),
+						},
+					],
+				},
+				action
+			);
+			expect(result.notes[0].unread).toBe(false);
+		});
+
 		it('replaces `seen` state for existing notifications with updates', function () {
 			const longAgo = '2017-08-01T18:20:00Z';
 			const action = { type: 'NOTES_RETRIEVED', notes };


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/sirbrillig/gitnews-menubar/issues/213

When you mark a notification as read:

1. The local Redux state immediately updates to unread: false
2. An async API call is made to GitHub to mark it as read.
3. If a fetch happens before the API call completes, GitHub still returns unread: true.
4. The mergeNotifications() function is only preserving gitnewsSeen and gitnewsMarkedUnread properties, but not the unread property.
5. This causes the local unread: false to be overwritten by GitHub's stale unread: true.

In this PR we preserve the local "mark as read" action when the note hasn't been updated on GitHub, preventing the race condition.
