### PR TITLE
Add small "@" mention icon to mention reason notes

### DIFF
--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -85,6 +85,7 @@ export default function Notification({
 
 	const lastUpdated = new Date(note.updatedAt);
 	const timeString = formatDistanceToNow(lastUpdated, { addSuffix: true });
+	const isMention = note.api.notification?.reason === 'mention';
 	const noteClasses = [
 		'notification',
 		...(isMultiOpenMode && !queuedAction ? ['notification--multi-open'] : []),
@@ -170,6 +171,7 @@ export default function Notification({
 				<div className="notification__image">
 					{isUnread && <span className="notification__new-dot" />}
 					{isMuted && <MuteIcon className="mute-icon" />}
+					{isMention && <span className="notification__mention-badge">@</span>}
 					<ImageWithBackup src={avatarSrc} username={note.commentUsername} />
 				</div>
 				<div className="notification__body">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -404,6 +404,24 @@ header h1 {
 	border-left: 4px solid #6b7ff5;
 }
 
+.notification__mention-badge {
+	position: absolute;
+	bottom: 0;
+	right: -4px;
+	width: 14px;
+	height: 14px;
+	border-radius: 50%;
+	border: 1.2px solid #fff;
+	background: #1a7bd3;
+	color: #fff;
+	font-size: 9px;
+	font-weight: bold;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
+}
+
 .notification__muted {
 	position: relative;
 }


### PR DESCRIPTION
This adds a small "@" badge to notifications with the `mention` reason, even if the notifications have not been filtered.

<img width="422" height="180" alt="Screenshot 2026-02-18 at 5 48 30 PM" src="https://github.com/user-attachments/assets/ff8f120c-8df1-4f3c-9b47-64d99573de1f" />
