### PR TITLE
Split fetching and enriching notes and use pagination

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,12 +22,18 @@ import debugFactory from 'debug';
 import AutoLaunch from 'easy-auto-launch';
 import dotEnv from 'dotenv';
 import {
-	fetchNotificationsForAccount,
+	listBasicNotificationsForAccount,
+	enrichNotificationsForAccount,
 	markNotficationAsRead,
 	unsubscribeFromNotification,
 } from './lib/github-interface';
 import { logMessage } from './lib/logging';
-import type { AccountInfo, FetchErrorObject, Note } from '../shared-types';
+import type {
+	AccountInfo,
+	BasicNote,
+	FetchErrorObject,
+	Note,
+} from '../shared-types';
 
 // These are provided by electron forge
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
@@ -162,22 +168,35 @@ ipcMain.handle('is-demo-mode:get', async () => {
 });
 
 ipcMain.handle(
-	'notifications-for-account:get',
+	'basic-notifications-for-account:list',
 	async (_event, account: AccountInfo) => {
 		try {
-			const notes = await fetchNotificationsForAccount(account);
-			return notes;
+			return await listBasicNotificationsForAccount(account);
 		} catch (error) {
 			// Electron IPC does not preserve Error objects so we must serialize what
 			// data we actually want. See
 			// https://github.com/electron/electron/issues/24427
+
 			logMessage(
-				`Failure while fetching notifications for account ${account.name} (${account.serverUrl})`,
+				`Failure while listing notifications for account ${account.name} (${account.serverUrl})`,
 				'error'
 			);
-			return {
-				error: encodeError(account.id, error as Error),
-			};
+			return { error: encodeError(account.id, error as Error) };
+		}
+	}
+);
+
+ipcMain.handle(
+	'notifications-for-account:enrich',
+	async (_event, account: AccountInfo, basicNotes: BasicNote[]) => {
+		try {
+			return await enrichNotificationsForAccount(account, basicNotes);
+		} catch (error) {
+			logMessage(
+				`Failure while enriching notifications for account ${account.name} (${account.serverUrl})`,
+				'error'
+			);
+			return { error: encodeError(account.id, error as Error) };
 		}
 	}
 );

--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -2,7 +2,12 @@ import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { fetch as undiciFetch, ProxyAgent } from 'undici';
 import { socksDispatcher } from 'fetch-socks';
 import { logMessage } from './logging';
-import type { AccountInfo, Note, NoteReason } from '../../shared-types';
+import type {
+	AccountInfo,
+	BasicNote,
+	Note,
+	NoteReason,
+} from '../../shared-types';
 import type { RequestInit } from 'undici';
 
 const userAgent = 'gitnews-menubar';
@@ -293,18 +298,48 @@ function isGithubActivityResponseValid(
 	return true;
 }
 
-export async function fetchNotificationsForAccount(
+function buildBasicNoteFromRaw(
+	account: AccountInfo,
+	n: RawNotification
+): BasicNote {
+	return {
+		id: n.id,
+		url: n.url,
+		repositoryFullName: n.repository.full_name,
+		repositoryName: n.repository.name,
+		repositoryOwnerAvatar: n.repository.owner.avatar_url,
+		reason: n.reason as NoteReason,
+		unread: n.unread,
+		updatedAt: n.updated_at,
+		title: n.subject.title,
+		type: n.subject.type,
+		subjectUrl: n.subject.url,
+		latestCommentUrl: n.subject.latest_comment_url ?? '',
+		gitnewsAccountId: account.id,
+	};
+}
+
+export async function listBasicNotificationsForAccount(
 	account: AccountInfo
-): Promise<Note[]> {
+): Promise<BasicNote[]> {
 	const octokit = createOctokit(account);
-	const notificationsResponse =
+
+	// Paginate ALL unread notifications (all: false = only unread)
+	const unreadRaw = await octokit.paginate(
+		octokit.rest.activity.listNotificationsForAuthenticatedUser,
+		{ all: false, per_page: 100 }
+	);
+
+	// Fetch first page of ALL notifications to capture recent read ones
+	const allRaw =
 		await octokit.rest.activity.listNotificationsForAuthenticatedUser({
 			all: true,
+			per_page: 100,
 		});
 
-	if (!isGithubActivityResponseValid(notificationsResponse)) {
+	if (!isGithubActivityResponseValid(allRaw)) {
 		logMessage(
-			`Raw notification data from account ${account.name} (${account.id}) is invalid: ${JSON.stringify(notificationsResponse)}`,
+			`Raw notification data from account ${account.name} (${account.id}) is invalid: ${JSON.stringify(allRaw)}`,
 			'error'
 		);
 		throw new Error(
@@ -312,14 +347,50 @@ export async function fetchNotificationsForAccount(
 		);
 	}
 
-	const notes: Note[] = [];
+	// Deduplicate: unread list takes precedence (it's the fully-paginated source)
+	const seen = new Set<string>();
+	const combined: RawNotification[] = [];
+	for (const n of [...unreadRaw, ...allRaw.data]) {
+		if (!seen.has(n.id)) {
+			seen.add(n.id);
+			combined.push(n as RawNotification);
+		}
+	}
 
-	// We need to make more requests to get the details of each notification. Do
-	// these fetches in parallel.
+	return combined.map((n) => buildBasicNoteFromRaw(account, n));
+}
+
+export async function enrichNotificationsForAccount(
+	account: AccountInfo,
+	basicNotes: BasicNote[]
+): Promise<Note[]> {
+	const octokit = createOctokit(account);
+	const notes: Note[] = [];
 	const promises = [];
-	for (const notification of notificationsResponse.data) {
+
+	for (const basicNote of basicNotes) {
+		// Reconstruct the RawNotification shape needed by existing helpers
+		const notification: RawNotification = {
+			id: basicNote.id,
+			url: basicNote.url,
+			subject: {
+				title: basicNote.title,
+				type: basicNote.type,
+				url: basicNote.subjectUrl,
+				latest_comment_url: basicNote.latestCommentUrl || basicNote.subjectUrl,
+			},
+			unread: basicNote.unread,
+			reason: basicNote.reason,
+			repository: {
+				full_name: basicNote.repositoryFullName,
+				name: basicNote.repositoryName,
+				owner: { avatar_url: basicNote.repositoryOwnerAvatar },
+			},
+			updated_at: basicNote.updatedAt,
+		};
+
 		logMessage(
-			`Fetching additional details for notification ${notification.id}`,
+			`Fetching additional details for notification ${basicNote.id}`,
 			'info'
 		);
 		const commentPromise = getCommentDataForNotification(
@@ -341,12 +412,7 @@ export async function fetchNotificationsForAccount(
 		promise
 			.then(([commentData, subjectData]) => {
 				notes.push(
-					buildNoteFromData({
-						account,
-						notification,
-						subjectData,
-						commentData,
-					})
+					buildNoteFromData({ account, notification, commentData, subjectData })
 				);
 			})
 			.catch((err) => {
@@ -357,6 +423,5 @@ export async function fetchNotificationsForAccount(
 	await Promise.all(promises).catch((err) => {
 		throw err;
 	});
-
 	return notes;
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,11 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { AccountInfo, IconType, MainBridge, Note } from './renderer/types';
+import {
+	AccountInfo,
+	BasicNote,
+	IconType,
+	MainBridge,
+	Note,
+} from './renderer/types';
 
 const bridge: MainBridge = {
 	quitApp: () => ipcRenderer.send('quit-app'),
@@ -18,8 +24,13 @@ const bridge: MainBridge = {
 	getVersion: () => ipcRenderer.invoke('version:get'),
 	isDemoMode: () => ipcRenderer.invoke('is-demo-mode:get'),
 	isAutoLaunchEnabled: () => ipcRenderer.invoke('is-auto-launch:get'),
-	getNotificationsForAccount: (account: AccountInfo) =>
-		ipcRenderer.invoke('notifications-for-account:get', account),
+	listBasicNotificationsForAccount: (account: AccountInfo) =>
+		ipcRenderer.invoke('basic-notifications-for-account:list', account),
+	enrichNotificationsForAccount: (
+		account: AccountInfo,
+		basicNotes: BasicNote[]
+	) =>
+		ipcRenderer.invoke('notifications-for-account:enrich', account, basicNotes),
 	markNotificationRead: (note: Note, account: AccountInfo) =>
 		ipcRenderer.invoke('mark-note-as-read', note, account),
 	unsubscribeNotification: (note: Note, account: AccountInfo) =>

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -19,9 +19,10 @@ import {
 	setIsTokenInvalid,
 } from '../lib/reducer';
 import {
-	AccountInfo,
 	AppReduxState,
+	BasicNote,
 	FetchErrorObject,
+	FilterType,
 	Note,
 	UnknownFetchError,
 } from '../types';
@@ -31,6 +32,14 @@ import { createDemoNotifications } from './demo-mode';
 const debug = debugFactory('gitnews-menubar');
 
 let currentDemoNotifications = createDemoNotifications();
+
+function doesBasicNoteMatchFilter(
+	note: BasicNote,
+	filterType: FilterType
+): boolean {
+	if (filterType === 'all') return true;
+	return note.reason === filterType;
+}
 
 export function createFetcher(): Middleware<unknown, AppReduxState> {
 	const fetcher: Middleware<object, AppReduxState> =
@@ -100,6 +109,23 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 				return;
 			}
 
+			if (action.type === 'SET_FILTER_TYPE') {
+				next(action); // update state.filterType FIRST so performFetch reads the new value
+				try {
+					performFetch(store.getState(), next);
+				} catch (err) {
+					window.electronApi.logMessage(
+						'Got an error fetching which somehow was not caught by the fetch handler',
+						'error'
+					);
+					console.error(
+						'Got an error fetching which somehow was not caught by the fetch handler',
+						err
+					);
+				}
+				return;
+			}
+
 			return next(action);
 		};
 
@@ -137,17 +163,82 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 			// NOTE: After this point, any return action MUST disable fetchingInProgress
 			// or the app will get stuck never updating again.
 			next(fetchBegin());
-			const getGithubNotifications = getFetcher(
-				state.accounts,
-				state.isDemoMode
-			);
-			const notes = await getGithubNotifications();
-			debug('notifications retrieved', notes);
+
+			let allNotes: Note[];
+
+			if (state.isDemoMode) {
+				allNotes = await getDemoNotifications();
+			} else {
+				// Phase 1 — List basic notes for all accounts in parallel
+				const allBasicNotes: BasicNote[] = [];
+				await Promise.all(
+					state.accounts.map((account) => {
+						window.electronApi.logMessage(
+							`Fetching notifications for ${account.name} (${account.serverUrl})`,
+							'info'
+						);
+						return window.electronApi
+							.listBasicNotificationsForAccount(account)
+							.then((result) => {
+								if ('error' in result) throw result.error;
+								allBasicNotes.push(...result);
+							})
+							.catch((err) => {
+								window.electronApi.logMessage(
+									`Fetching notifications FAILED for ${account.name} (${account.serverUrl})`,
+									'error'
+								);
+								throw err;
+							});
+					})
+				);
+
+				// Phase 2 — Filter (renderer-side)
+				const locallyUnreadIds = new Set(
+					(state.locallyUnreadNotes ?? []).map((n) => n.gitnewsAccountId + n.id)
+				);
+				const toEnrich = allBasicNotes.filter((note) => {
+					if (locallyUnreadIds.has(note.gitnewsAccountId + note.id))
+						return true;
+					if (state.mutedRepos.includes(note.repositoryFullName)) return false;
+					return doesBasicNoteMatchFilter(note, state.filterType);
+				});
+
+				// Phase 3 — Enrich (grouped by account)
+				const byAccount = new Map<string, BasicNote[]>();
+				for (const note of toEnrich) {
+					const group = byAccount.get(note.gitnewsAccountId) ?? [];
+					group.push(note);
+					byAccount.set(note.gitnewsAccountId, group);
+				}
+
+				allNotes = [];
+				await Promise.all(
+					[...byAccount.entries()].map(([accountId, notes]) => {
+						const account = state.accounts.find((a) => a.id === accountId);
+						if (!account) return Promise.resolve();
+						return window.electronApi
+							.enrichNotificationsForAccount(account, notes)
+							.then((result) => {
+								if ('error' in result) throw result.error;
+								allNotes.push(...result);
+							});
+					})
+				);
+
+				allNotes.sort((a, b) => {
+					if (a.updatedAt < b.updatedAt) return 1;
+					if (a.updatedAt > b.updatedAt) return -1;
+					return 0;
+				});
+			}
+
+			debug('notifications retrieved', allNotes);
 			window.electronApi.logMessage(
-				`Notifications retrieved (${notes.length} found in ${state.accounts.length} accounts)`,
+				`Notifications retrieved (${allNotes.length} found in ${state.accounts.length} accounts)`,
 				'info'
 			);
-			next(gotNotes(notes));
+			next(gotNotes(allNotes));
 		} catch (err) {
 			debug('Fetching notifications threw an error', err);
 			window.electronApi.logMessage(
@@ -160,69 +251,7 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 		}
 	}
 
-	function getFetcher(
-		accounts: AccountInfo[],
-		isDemoMode: boolean
-	): () => Promise<Note[]> {
-		if (isDemoMode) {
-			return () => getDemoNotifications();
-		}
-		return async () => {
-			let allNotes: Note[] = [];
-
-			const promises = [];
-
-			// Do the fetching in parallel.
-			for (const account of accounts) {
-				window.electronApi.logMessage(
-					`Fetching notifications for ${account.name} (${account.serverUrl})`,
-					'info'
-				);
-				const promise = fetchNotifications(account)
-					.then((notes) => {
-						if ('error' in notes) {
-							throw notes.error;
-						}
-						allNotes = [...allNotes, ...notes];
-					})
-					.catch((err) => {
-						window.electronApi.logMessage(
-							`Fetching notifications FAILED for ${account.name} (${account.serverUrl})`,
-							'error'
-						);
-						throw err;
-					});
-				promises.push(promise);
-			}
-
-			await Promise.all(promises).catch((err) => {
-				window.electronApi.logMessage(
-					`Waiting for fetched notifications FAILED`,
-					'error'
-				);
-				throw err;
-			});
-
-			allNotes.sort((a, b) => {
-				if (a.updatedAt < b.updatedAt) {
-					return 1;
-				}
-				if (a.updatedAt > b.updatedAt) {
-					return -1;
-				}
-				return 0;
-			});
-			return allNotes;
-		};
-	}
-
 	return fetcher;
-}
-
-async function fetchNotifications(
-	account: AccountInfo
-): Promise<Note[] | { error: Error }> {
-	return window.electronApi.getNotificationsForAccount(account);
 }
 
 async function getDemoNotifications(): Promise<Note[]> {

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -9,10 +9,11 @@ import type {
 	NoteReason,
 	Note,
 	AccountInfo,
+	BasicNote,
 	FetchErrorObject,
 } from '../shared-types';
 
-export type { NoteReason, Note, AccountInfo, FetchErrorObject };
+export type { NoteReason, Note, AccountInfo, BasicNote, FetchErrorObject };
 
 export type FilterType = NoteReason | 'all';
 
@@ -166,9 +167,13 @@ export interface MainBridge {
 	onClick: (callback: () => void) => void;
 	getToken: () => Promise<string>;
 	getVersion: () => Promise<string>;
-	getNotificationsForAccount: (
+	listBasicNotificationsForAccount: (
 		account: AccountInfo
-	) => Promise<Note[] | { error: Error }>;
+	) => Promise<BasicNote[] | { error: FetchErrorObject }>;
+	enrichNotificationsForAccount: (
+		account: AccountInfo,
+		basicNotes: BasicNote[]
+	) => Promise<Note[] | { error: FetchErrorObject }>;
 	markNotificationRead: (note: Note, account: AccountInfo) => void;
 	unsubscribeNotification: (note: Note, account: AccountInfo) => void;
 	isDemoMode: () => Promise<boolean>;

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -51,6 +51,22 @@ export interface Note {
 	gitnewsAccountId: AccountInfo['id'];
 }
 
+export interface BasicNote {
+	id: string;
+	url: string;
+	repositoryFullName: string;
+	repositoryName: string;
+	repositoryOwnerAvatar: string;
+	reason: NoteReason;
+	unread: boolean;
+	updatedAt: string;
+	title: string;
+	type: string;
+	subjectUrl: string;
+	latestCommentUrl: string;
+	gitnewsAccountId: string;
+}
+
 export interface AccountInfo {
 	id: string;
 	name: string;

--- a/tests/gitnews-fetcher-fetch.js
+++ b/tests/gitnews-fetcher-fetch.js
@@ -1,0 +1,369 @@
+/* globals describe, it, beforeEach */
+const { createFetcher } = require('../src/renderer/lib/gitnews-fetcher');
+
+// Flush all pending microtasks and macrotasks so async middleware completes
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+window.electronApi = {
+	quitApp: () => undefined,
+	logMessage: () => undefined,
+	toggleAutoLaunch: () => undefined,
+	openUrl: () => undefined,
+	setIcon: () => undefined,
+	onHide: () => undefined,
+	onShow: () => undefined,
+	onClick: () => undefined,
+	getToken: () => Promise.resolve(''),
+	getVersion: () => Promise.resolve('v1'),
+	isDemoMode: () => Promise.resolve(false),
+	isAutoLaunchEnabled: () => Promise.resolve(false),
+	listBasicNotificationsForAccount: jest.fn().mockResolvedValue([]),
+	enrichNotificationsForAccount: jest.fn().mockResolvedValue([]),
+};
+
+const TEST_ACCOUNT = {
+	id: 'acc1',
+	name: 'Test Account',
+	apiKey: 'test-key',
+	serverUrl: 'https://api.github.com',
+};
+
+function makeState(overrides = {}) {
+	return {
+		accounts: [TEST_ACCOUNT],
+		mutedRepos: [],
+		filterType: 'all',
+		fetchingInProgress: false,
+		fetchingStartedAt: false,
+		isDemoMode: false,
+		locallyUnreadNotes: [],
+		notes: [],
+		...overrides,
+	};
+}
+
+function makeBasicNote(overrides = {}) {
+	return {
+		id: 'note1',
+		url: 'https://api.github.com/notifications/threads/1',
+		repositoryFullName: 'owner/repo',
+		repositoryName: 'repo',
+		repositoryOwnerAvatar: 'https://example.com/avatar.png',
+		reason: 'mention',
+		unread: true,
+		updatedAt: '2024-01-01T00:00:00Z',
+		title: 'Test Note',
+		type: 'Issue',
+		subjectUrl: 'https://api.github.com/repos/owner/repo/issues/1',
+		latestCommentUrl:
+			'https://api.github.com/repos/owner/repo/issues/comments/1',
+		gitnewsAccountId: 'acc1',
+		...overrides,
+	};
+}
+
+// Create middleware and return a dispatch function + the next spy
+function makeMiddleware(state) {
+	let currentState = state;
+	const next = jest.fn((action) => {
+		// Simulate Redux updating state when SET_FILTER_TYPE is forwarded,
+		// so performFetch reads the new filterType from store.getState()
+		if (action.type === 'SET_FILTER_TYPE') {
+			currentState = { ...currentState, filterType: action.filterType };
+		}
+	});
+	const store = { getState: () => currentState };
+	const dispatch = createFetcher()(store)(next);
+	return { dispatch, next };
+}
+
+describe('createFetcher() — two-phase fetch', function () {
+	beforeEach(function () {
+		window.electronApi.listBasicNotificationsForAccount = jest
+			.fn()
+			.mockResolvedValue([]);
+		window.electronApi.enrichNotificationsForAccount = jest
+			.fn()
+			.mockResolvedValue([]);
+	});
+
+	describe('Phase 1 — list', function () {
+		it('calls listBasicNotificationsForAccount once per account', async function () {
+			const accounts = [
+				TEST_ACCOUNT,
+				{ id: 'acc2', name: 'Account 2', apiKey: 'key2', serverUrl: 'https://api.github.com' },
+			];
+			const { dispatch } = makeMiddleware(makeState({ accounts }));
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.listBasicNotificationsForAccount
+			).toHaveBeenCalledTimes(2);
+			expect(
+				window.electronApi.listBasicNotificationsForAccount
+			).toHaveBeenCalledWith(accounts[0]);
+			expect(
+				window.electronApi.listBasicNotificationsForAccount
+			).toHaveBeenCalledWith(accounts[1]);
+		});
+	});
+
+	describe('Phase 2 — filter', function () {
+		it('passes unfiltered notes to enrichment', async function () {
+			const note = makeBasicNote();
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				note,
+			]);
+			const { dispatch } = makeMiddleware(makeState());
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(TEST_ACCOUNT, [note]);
+		});
+
+		it('excludes notes from muted repos before enrichment', async function () {
+			const mutedNote = makeBasicNote({
+				id: 'muted',
+				repositoryFullName: 'owner/muted-repo',
+			});
+			const normalNote = makeBasicNote({
+				id: 'normal',
+				repositoryFullName: 'owner/good-repo',
+			});
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				mutedNote,
+				normalNote,
+			]);
+			const state = makeState({ mutedRepos: ['owner/muted-repo'] });
+			const { dispatch } = makeMiddleware(state);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(TEST_ACCOUNT, [normalNote]);
+		});
+
+		it('excludes notes whose reason does not match filterType', async function () {
+			const mentionNote = makeBasicNote({ id: 'n1', reason: 'mention' });
+			const subscribedNote = makeBasicNote({ id: 'n2', reason: 'subscribed' });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				mentionNote,
+				subscribedNote,
+			]);
+			const state = makeState({ filterType: 'mention' });
+			const { dispatch } = makeMiddleware(state);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(TEST_ACCOUNT, [mentionNote]);
+		});
+
+		it('passes all notes when filterType is "all"', async function () {
+			const mentionNote = makeBasicNote({ id: 'n1', reason: 'mention' });
+			const subscribedNote = makeBasicNote({ id: 'n2', reason: 'subscribed' });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				mentionNote,
+				subscribedNote,
+			]);
+			const state = makeState({ filterType: 'all' });
+			const { dispatch } = makeMiddleware(state);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(
+				TEST_ACCOUNT,
+				expect.arrayContaining([mentionNote, subscribedNote])
+			);
+		});
+
+		it('does not call enrichNotificationsForAccount when all notes are filtered out', async function () {
+			const mutedNote = makeBasicNote({ repositoryFullName: 'owner/muted' });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				mutedNote,
+			]);
+			const state = makeState({ mutedRepos: ['owner/muted'] });
+			const { dispatch } = makeMiddleware(state);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).not.toHaveBeenCalled();
+		});
+
+		it('enriches locally-unread notes even when their repo is muted', async function () {
+			const note = makeBasicNote({
+				id: 'lu-note',
+				repositoryFullName: 'owner/muted-repo',
+				gitnewsAccountId: 'acc1',
+			});
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				note,
+			]);
+			const state = makeState({
+				mutedRepos: ['owner/muted-repo'],
+				locallyUnreadNotes: [{ id: 'lu-note', gitnewsAccountId: 'acc1' }],
+			});
+			const { dispatch } = makeMiddleware(state);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(TEST_ACCOUNT, [note]);
+		});
+
+		it('enriches locally-unread notes even when their reason does not match filterType', async function () {
+			const note = makeBasicNote({
+				id: 'lu-note',
+				reason: 'subscribed',
+				gitnewsAccountId: 'acc1',
+			});
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				note,
+			]);
+			const state = makeState({
+				filterType: 'mention',
+				locallyUnreadNotes: [{ id: 'lu-note', gitnewsAccountId: 'acc1' }],
+			});
+			const { dispatch } = makeMiddleware(state);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(TEST_ACCOUNT, [note]);
+		});
+	});
+
+	describe('Phase 3 — enrich', function () {
+		it('dispatches NOTES_RETRIEVED with the enriched notes', async function () {
+			const basicNote = makeBasicNote();
+			const enrichedNote = { id: 'note1', title: 'Enriched', updatedAt: '2024-01-01T00:00:00Z' };
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				basicNote,
+			]);
+			window.electronApi.enrichNotificationsForAccount.mockResolvedValue([
+				enrichedNote,
+			]);
+			const { dispatch, next } = makeMiddleware(makeState());
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(next).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'NOTES_RETRIEVED',
+					notes: [enrichedNote],
+				})
+			);
+		});
+
+		it('dispatches enriched notes sorted by updatedAt descending', async function () {
+			const olderNote = makeBasicNote({
+				id: 'older',
+				updatedAt: '2024-01-01T00:00:00Z',
+			});
+			const newerNote = makeBasicNote({
+				id: 'newer',
+				updatedAt: '2024-06-01T00:00:00Z',
+			});
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				olderNote,
+				newerNote,
+			]);
+			const enrichedOlder = { id: 'older', updatedAt: '2024-01-01T00:00:00Z' };
+			const enrichedNewer = { id: 'newer', updatedAt: '2024-06-01T00:00:00Z' };
+			// Return in wrong order to prove sorting happens
+			window.electronApi.enrichNotificationsForAccount.mockResolvedValue([
+				enrichedOlder,
+				enrichedNewer,
+			]);
+			const { dispatch, next } = makeMiddleware(makeState());
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			const gotNotesCall = next.mock.calls.find(
+				(call) => call[0]?.type === 'NOTES_RETRIEVED'
+			);
+			expect(gotNotesCall[0].notes[0].id).toBe('newer');
+			expect(gotNotesCall[0].notes[1].id).toBe('older');
+		});
+
+		it('groups notes by account before calling enrichNotificationsForAccount', async function () {
+			const acc2 = { id: 'acc2', name: 'Account 2', apiKey: 'key2', serverUrl: 'https://api.github.com' };
+			const noteAcc1 = makeBasicNote({ id: 'n1', gitnewsAccountId: 'acc1' });
+			const noteAcc2 = makeBasicNote({ id: 'n2', gitnewsAccountId: 'acc2' });
+			window.electronApi.listBasicNotificationsForAccount
+				.mockResolvedValueOnce([noteAcc1])
+				.mockResolvedValueOnce([noteAcc2]);
+			const state = makeState({ accounts: [TEST_ACCOUNT, acc2] });
+			const { dispatch } = makeMiddleware(state);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledTimes(2);
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(TEST_ACCOUNT, [noteAcc1]);
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(acc2, [noteAcc2]);
+		});
+	});
+
+	describe('SET_FILTER_TYPE action', function () {
+		it('forwards the action to next before fetching', async function () {
+			const { dispatch, next } = makeMiddleware(makeState());
+			const action = { type: 'SET_FILTER_TYPE', filterType: 'mention' };
+			dispatch(action);
+			expect(next).toHaveBeenCalledWith(action);
+		});
+
+		it('triggers a fetch after updating filter type', async function () {
+			const { dispatch } = makeMiddleware(makeState());
+			dispatch({ type: 'SET_FILTER_TYPE', filterType: 'mention' });
+			await flushPromises();
+			expect(
+				window.electronApi.listBasicNotificationsForAccount
+			).toHaveBeenCalled();
+		});
+
+		it('uses the new filterType when fetching', async function () {
+			const mentionNote = makeBasicNote({ id: 'n1', reason: 'mention' });
+			const subscribedNote = makeBasicNote({ id: 'n2', reason: 'subscribed' });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				mentionNote,
+				subscribedNote,
+			]);
+			// Start with filterType 'all'; SET_FILTER_TYPE switches to 'mention'
+			const { dispatch } = makeMiddleware(makeState({ filterType: 'all' }));
+			dispatch({ type: 'SET_FILTER_TYPE', filterType: 'mention' });
+			await flushPromises();
+			// Only the mention note should be passed to enrichment
+			expect(
+				window.electronApi.enrichNotificationsForAccount
+			).toHaveBeenCalledWith(TEST_ACCOUNT, [mentionNote]);
+		});
+	});
+
+	describe('fetch lifecycle', function () {
+		it('dispatches FETCH_BEGIN before fetching and FETCH_END after', async function () {
+			const { dispatch, next } = makeMiddleware(makeState());
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			const types = next.mock.calls.map((call) => call[0]?.type);
+			expect(types[0]).toBe('FETCH_BEGIN');
+			expect(types[types.length - 1]).toBe('FETCH_END');
+		});
+
+		it('skips fetching when another fetch is already in progress', async function () {
+			const { dispatch } = makeMiddleware(
+				makeState({ fetchingInProgress: true, fetchingStartedAt: Date.now() })
+			);
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(
+				window.electronApi.listBasicNotificationsForAccount
+			).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
This PR modifies the note fetching behavior so that instead of fetching and enriching (fetching additional data about the note) in one pass, we instead fetch basic notes first and then enrich later. The main benefit of this is that we can use pagination to make sure that we never miss an unread notification even if there are filters applied (muted repos, filting by "assigned", etc).

Fixes https://github.com/sirbrillig/gitnews-menubar/issues/154

### Problem

Previously, the app fetched notifications with a single call using GitHub's default page size of 50. All filtering then happened client-side on those 50 results. When a user had many notifications that didn't match their active filter, the app would display very few — or none — even though matching notifications existed beyond the first page.

### What changed

The fetch is now split into three phases:

1. **List** (main process): paginates *all* unread notifications plus fetches the first 100 of all notifications (read + unread), deduplicates, and returns lightweight `BasicNote` objects with no enrichment yet.
2. **Filter** (renderer): applies `filterType` and `mutedRepos` to the `BasicNote` list before any expensive API calls. Notes in `locallyUnreadNotes` are always kept regardless of filter.
3. **Enrich** (main process): fetches comment and subject data only for the filtered-in subset, returning full `Note` objects.

This means filtering now operates on a much larger set of notifications, so the displayed list reflects the user's actual unread activity rather than an artifact of page size.

A `SET_FILTER_TYPE` action now also triggers a re-fetch so the list updates immediately when the user changes the filter.
