### PR TITLE
Always show settings button when app has accounts configured

### DIFF
--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -63,6 +63,7 @@ interface AppConnectedProps {
 	isLogging: boolean;
 	isTokenInvalid: boolean;
 	showUnreadOnly: boolean;
+	hasAccounts: boolean;
 }
 
 interface AppConnectedActions {
@@ -206,6 +207,7 @@ class App extends React.Component<AppProps, AppState> {
 			lastSuccessfulCheck,
 			getVersion,
 			fetchingInProgress,
+			hasAccounts,
 		} = this.props;
 		const newNotes = this.getUnreadNotifications();
 		const readNotes = this.props.showUnreadOnly ? [] : this.getReadNotifications();
@@ -235,7 +237,7 @@ class App extends React.Component<AppProps, AppState> {
 		const backButtonPanes = [PANE_CONFIG, PANE_MUTED_REPOS, PANE_ACCOUNTS];
 		const confugSubPanes = [PANE_MUTED_REPOS, PANE_ACCOUNTS];
 		const showBackButton = (() => {
-			if (!token) {
+			if (!hasAccounts) {
 				return false;
 			}
 			if (backButtonPanes.includes(currentPane)) {
@@ -252,7 +254,7 @@ class App extends React.Component<AppProps, AppState> {
 		};
 
 		const headerOnClickConfig = (() => {
-			if (token && currentPane === PANE_NOTIFICATIONS) {
+			if (hasAccounts && currentPane === PANE_NOTIFICATIONS) {
 				return showConfig;
 			}
 			return undefined;
@@ -336,6 +338,7 @@ function mapStateToProps(state: AppReduxState): AppConnectedProps {
 		isLogging: state.isLogging,
 		isTokenInvalid: state.isTokenInvalid,
 		showUnreadOnly: state.showUnreadOnly,
+		hasAccounts: state.accounts.length > 0 || Boolean(state.token),
 	};
 }
 


### PR DESCRIPTION
## Summary

- The settings cog button was gated on the legacy `token` field, which is empty for users on the multi-account system
- On first launch (showing "Preparing to fetch notifications"), users had no way to open settings to check/fix their configuration
- Replaced the `token` check with `hasAccounts` (derived from `accounts.length > 0 || Boolean(state.token)`) so the button is always visible once the app is configured

## Test plan

- [ ] Open the app for the first time (or with `lastSuccessfulCheck` cleared) — settings cog should be visible while "Preparing to fetch notifications" is shown
- [ ] Verify settings button still works normally once notifications load
- [ ] Verify the back button still works correctly when navigating into settings sub-panes
- [ ] Verify no settings button appears before any accounts are configured (fresh install, account setup screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)