### PR TITLE
Fix: allow one account fetch to fail without blocking others

### DIFF
--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -329,10 +329,20 @@ export async function listBasicNotificationsForAccount(
 ): Promise<BasicNote[]> {
 	const octokit = createOctokit(account);
 
+	logMessage(
+		`Asking octokit to fetch all unread notifications (paginated) for account ${account.name} (${account.id})`,
+		'info'
+	);
+
 	// Paginate ALL unread notifications (all: false = only unread)
 	const unreadRaw = await octokit.paginate(
 		octokit.rest.activity.listNotificationsForAuthenticatedUser,
 		{ all: false, per_page: 100 }
+	);
+
+	logMessage(
+		`Fetched ${unreadRaw.length} unread notifications. Asking octokit to fetch first page of all notifications for account ${account.name} (${account.id})`,
+		'info'
 	);
 
 	// Fetch first page of ALL notifications to capture recent read ones
@@ -341,6 +351,11 @@ export async function listBasicNotificationsForAccount(
 			all: true,
 			per_page: 100,
 		});
+
+	logMessage(
+		`All recent notifications fetched for account ${account.name} (${account.id})`,
+		'info'
+	);
 
 	if (!isGithubActivityResponseValid(allRaw)) {
 		logMessage(
@@ -395,7 +410,7 @@ export async function enrichNotificationsForAccount(
 		};
 
 		logMessage(
-			`Fetching additional details for notification ${basicNote.id}`,
+			`Fetching additional details for notification ${basicNote.id} in account ${account.name} (${account.id})`,
 			'info'
 		);
 		const commentPromise = getCommentDataForNotification(

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -19,6 +19,7 @@ import {
 	setIsTokenInvalid,
 } from '../lib/reducer';
 import {
+	type AccountInfo,
 	AppReduxState,
 	BasicNote,
 	FetchErrorObject,
@@ -164,13 +165,23 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 			// or the app will get stuck never updating again.
 			next(fetchBegin());
 
-			let allNotes: Note[];
-
 			if (state.isDemoMode) {
-				allNotes = await getDemoNotifications();
+				const allNotes = await getDemoNotifications();
+				debug('notifications retrieved', allNotes);
+				window.electronApi.logMessage(
+					`Notifications retrieved (${allNotes.length} found in ${state.accounts.length} accounts)`,
+					'info'
+				);
+				next(gotNotes(allNotes));
 			} else {
+				type AccountError = {
+					account: AccountInfo;
+					err: FetchErrorObject | unknown;
+				};
+
 				// Phase 1 — List basic notes for all accounts in parallel
 				const allBasicNotes: BasicNote[] = [];
+				const phase1Errors: AccountError[] = [];
 				await Promise.all(
 					state.accounts.map((account) => {
 						window.electronApi.logMessage(
@@ -180,7 +191,14 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 						return window.electronApi
 							.listBasicNotificationsForAccount(account)
 							.then((result) => {
-								if ('error' in result) throw result.error;
+								if ('error' in result) {
+									window.electronApi.logMessage(
+										`Fetching notifications FAILED for ${account.name} (${account.serverUrl})`,
+										'error'
+									);
+									phase1Errors.push({ account, err: result.error });
+									return;
+								}
 								allBasicNotes.push(...result);
 							})
 							.catch((err) => {
@@ -188,7 +206,7 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 									`Fetching notifications FAILED for ${account.name} (${account.serverUrl})`,
 									'error'
 								);
-								throw err;
+								phase1Errors.push({ account, err });
 							});
 					})
 				);
@@ -212,7 +230,8 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 					byAccount.set(note.gitnewsAccountId, group);
 				}
 
-				allNotes = [];
+				const allNotes: Note[] = [];
+				const phase3Errors: AccountError[] = [];
 				await Promise.all(
 					[...byAccount.entries()].map(([accountId, notes]) => {
 						const account = state.accounts.find((a) => a.id === accountId);
@@ -220,25 +239,55 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 						return window.electronApi
 							.enrichNotificationsForAccount(account, notes)
 							.then((result) => {
-								if ('error' in result) throw result.error;
+								if ('error' in result) {
+									phase3Errors.push({ account, err: result.error });
+									return;
+								}
 								allNotes.push(...result);
+							})
+							.catch((err) => {
+								phase3Errors.push({ account, err });
 							});
 					})
 				);
+
+				const allAccountErrors = [...phase1Errors, ...phase3Errors];
+				const failedAccountIds = new Set(
+					allAccountErrors.map((e) => e.account.id)
+				);
+				const anyAccountSucceeded = state.accounts.some(
+					(a) => !failedAccountIds.has(a.id)
+				);
+
+				if (anyAccountSucceeded) {
+					// Preserve existing notes from failed accounts so they don't disappear
+					const preservedNotes = state.notes.filter((n) =>
+						failedAccountIds.has(n.gitnewsAccountId)
+					);
+					allNotes.push(...preservedNotes);
+				}
 
 				allNotes.sort((a, b) => {
 					if (a.updatedAt < b.updatedAt) return 1;
 					if (a.updatedAt > b.updatedAt) return -1;
 					return 0;
 				});
-			}
 
-			debug('notifications retrieved', allNotes);
-			window.electronApi.logMessage(
-				`Notifications retrieved (${allNotes.length} found in ${state.accounts.length} accounts)`,
-				'info'
-			);
-			next(gotNotes(allNotes));
+				debug('notifications retrieved', allNotes);
+				window.electronApi.logMessage(
+					`Notifications retrieved (${allNotes.length} found in ${state.accounts.length} accounts, ${allAccountErrors.length} account(s) failed)`,
+					'info'
+				);
+
+				if (anyAccountSucceeded) {
+					// gotNotes clears errors[], so dispatch it before per-account errors
+					next(gotNotes(allNotes));
+				}
+
+				for (const { account, err } of allAccountErrors) {
+					dispatchAccountFetchError(next, account, err as FetchErrorObject);
+				}
+			}
 		} catch (err) {
 			debug('Fetching notifications threw an error', err);
 			window.electronApi.logMessage(
@@ -260,6 +309,24 @@ async function getDemoNotifications(): Promise<Note[]> {
 		...createDemoNotifications(),
 	];
 	return currentDemoNotifications;
+}
+
+function dispatchAccountFetchError(
+	dispatch: AppDispatch,
+	account: AccountInfo,
+	err: FetchErrorObject
+) {
+	if (typeof err === 'object' && isTokenInvalid(err)) {
+		const message = `Token is invalid for account "${account.name}"`;
+		debug(message);
+		window.electronApi.logMessage(message, 'warn');
+		dispatch(setIsTokenInvalid(err.accountId ?? account.id, true));
+		return;
+	}
+	const message = `Error fetching notifications for "${account.name}": ${getErrorMessage(err as UnknownFetchError)}`;
+	debug(message);
+	window.electronApi.logMessage(message, 'warn');
+	dispatch(addConnectionError(message));
 }
 
 export function getErrorHandler(dispatch: AppDispatch) {


### PR DESCRIPTION
## Summary

- Fixes a bug where a failing account (e.g. wrong proxy settings for a GitHub Enterprise account) would abort the entire notification fetch and leave the app stuck on \"Checking for notifications...\" forever
- Per-account errors are now collected independently instead of re-thrown, so a failing account no longer causes `Promise.all` to reject and kill the fetch for all other accounts
- When at least one account succeeds, `gotNotes()` is dispatched with fresh notes plus preserved (stale) notes from any failed accounts, so notifications from failed accounts don't vanish from the UI
- Per-account error messages are shown in the errors area (e.g. \"Error fetching notifications for \"My GHE Account\": ...\") after a successful partial fetch

## Root cause

In `gitnews-fetcher.ts`, both Phase 1 (listing notifications) and Phase 3 (enriching) used `throw err` inside `.catch()` and `.then()` handlers, which propagated rejections through `Promise.all`. The outer `catch` handler then called `changeToOffline()` or `addConnectionError()` but crucially never called `gotNotes()`, so `lastSuccessfulCheck` stayed `false` and the `UncheckedNotice` component ("Checking for notifications...") was shown indefinitely.

## Test plan

- [ ] Verify that with two accounts configured, if one has an incorrect proxy URL, the other account's notifications still load normally
- [ ] Verify that an error message appears in the UI identifying the failing account
- [ ] Verify that previously-fetched notifications from the failing account are preserved (not cleared) in the UI
- [ ] Verify that with a single account that fails, the existing notes remain visible and an error message is shown
- [ ] Run `yarn test` — all 63 tests pass
- [ ] Run `yarn typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)