### PR TITLE
Restyle settings, accounts, and muted repos pages

### DIFF
--- a/src/renderer/components/account-list.tsx
+++ b/src/renderer/components/account-list.tsx
@@ -25,49 +25,56 @@ export default function AccountList({
 
 	return (
 		<div className="config-page">
-			<div className="account-page-header">
-				<h2 className="config-page__title">Accounts</h2>
-				<div className="account-page-actions">
-					{hasSelectedAccountBeenDeleted && selectedAccount && <button
-						className="add-account-button btn"
-						onClick={() => {
-							dispatch(setAccounts([selectedAccount, ...accounts]));
-						}}
-					>
-						Restore '{selectedAccount.name}'
-					</button>}
-					<button
-						className="add-account-button btn"
-						onClick={() => {
-							const newAccount: AccountInfo = {
-								id: crypto.randomUUID(),
-								name: '',
-								apiKey: '',
-								serverUrl: 'https://github.com',
-							};
-							dispatch(selectAccount(newAccount));
-							showAccountEdit();
-						}}
-					>
-						New
-					</button>
-				</div>
-			</div>
-			<ul className="account-list">
-				{accounts.map((account) => {
-					return (
-						<li
-							key={account.id}
+			<div className="config-section">
+				<div className="config-section__header">
+					<div className="config-section__label">Accounts</div>
+					<div className="config-section__actions">
+						{hasSelectedAccountBeenDeleted && selectedAccount && (
+							<button
+								className="add-account-button config-section__action-button"
+								onClick={() => {
+									dispatch(setAccounts([selectedAccount, ...accounts]));
+								}}
+							>
+								Restore &lsquo;{selectedAccount.name}&rsquo;
+							</button>
+						)}
+						<button
+							className="add-account-button config-section__action-button"
 							onClick={() => {
-								dispatch(selectAccount(account));
+								const newAccount: AccountInfo = {
+									id: crypto.randomUUID(),
+									name: '',
+									apiKey: '',
+									serverUrl: 'https://github.com',
+								};
+								dispatch(selectAccount(newAccount));
 								showAccountEdit();
 							}}
 						>
-							{account.name ?? 'Unnamed'}: {account.serverUrl}
-						</li>
-					);
-				})}
-			</ul>
+							+ New
+						</button>
+					</div>
+				</div>
+				<ul className="account-list">
+					{accounts.map((account) => {
+						return (
+							<li
+								key={account.id}
+								onClick={() => {
+									dispatch(selectAccount(account));
+									showAccountEdit();
+								}}
+							>
+								<div className="account-list__info">
+									<span className="account-list__name">{account.name ?? 'Unnamed'}</span>
+									<span className="account-list__url">{account.serverUrl}</span>
+								</div>
+							</li>
+						);
+					})}
+				</ul>
+			</div>
 		</div>
 	);
 }

--- a/src/renderer/components/config-page.tsx
+++ b/src/renderer/components/config-page.tsx
@@ -31,50 +31,42 @@ export default function ConfigPage({
 
 	return (
 		<div className="config-page">
-			<h2 className="config-page__title">Configuration</h2>
-			<h3>Settings</h3>
-			<ul className="config-page__settings">
-				<li>
-					<button className="edit-token-button btn--cancel" onClick={showAccounts}>
-						Edit account information
-					</button>
-				</li>
-				<li>
-					<button
-						className="edit-muted-repos-button btn--cancel"
-						onClick={showMutedReposList}
-					>
-						Edit muted repos
-					</button>
-				</li>
-				<li>
-					<input
-						type="checkbox"
-						id="auto-load-setting"
-						className="auto-load-setting"
-						checked={isAutoLoadEnabled}
-						onChange={toggleAutoLoad}
-					/>
-					<label
-						htmlFor="auto-load-setting"
-						className="auto-load-setting-label"
-					>
-						Launch Gitnews at login
-					</label>
-				</li>
-				<li>
-					<input
-						type="checkbox"
-						id="logging-setting"
-						className="logging-setting"
-						checked={isLogging}
-						onChange={toggleIsLogging}
-					/>
-					<label htmlFor="logging-setting" className="logging-setting-label">
-						Enable error logging
-					</label>
-				</li>
-			</ul>
+			<div className="config-section">
+				<div className="config-section__label">Settings</div>
+				<ul className="config-page__settings">
+					<li className="config-row config-row--nav">
+						<button className="edit-token-button" onClick={showAccounts}>
+							Accounts
+						</button>
+					</li>
+					<li className="config-row config-row--nav">
+						<button
+							className="edit-muted-repos-button"
+							onClick={showMutedReposList}
+						>
+							Muted repos
+						</button>
+					</li>
+					<li className="config-row config-row--toggle">
+						<label htmlFor="auto-load-setting">Launch at login</label>
+						<input
+							type="checkbox"
+							id="auto-load-setting"
+							checked={isAutoLoadEnabled}
+							onChange={toggleAutoLoad}
+						/>
+					</li>
+					<li className="config-row config-row--toggle">
+						<label htmlFor="logging-setting">Enable error logging</label>
+						<input
+							type="checkbox"
+							id="logging-setting"
+							checked={isLogging}
+							onChange={toggleIsLogging}
+						/>
+					</li>
+				</ul>
+			</div>
 			<Attributions openUrl={openUrl} />
 			<div className="config-page__buttons">
 				<button className="btn--cancel quit-button" onClick={quitApp}>

--- a/src/renderer/components/config-page.tsx
+++ b/src/renderer/components/config-page.tsx
@@ -35,13 +35,13 @@ export default function ConfigPage({
 			<h3>Settings</h3>
 			<ul className="config-page__settings">
 				<li>
-					<button className="edit-token-button" onClick={showAccounts}>
+					<button className="edit-token-button btn--cancel" onClick={showAccounts}>
 						Edit account information
 					</button>
 				</li>
 				<li>
 					<button
-						className="edit-muted-repos-button"
+						className="edit-muted-repos-button btn--cancel"
 						onClick={showMutedReposList}
 					>
 						Edit muted repos

--- a/src/renderer/components/filter-button.tsx
+++ b/src/renderer/components/filter-button.tsx
@@ -38,7 +38,7 @@ export default function FilterButton({
 		setFiltersVisible(false);
 	};
 	return (
-		<div className="filter-button__area">
+		<div className={`filter-button__area${filterType !== 'all' ? ' filter-button__area--active' : ''}`}>
 			{filterType !== 'all' && (
 				<label
 					className="filter-label"

--- a/src/renderer/components/muted-repos-list.tsx
+++ b/src/renderer/components/muted-repos-list.tsx
@@ -9,9 +9,15 @@ export default function MutedReposList({
 	unmuteRepo: (note: string) => void;
 }) {
 	return (
-		<div className="muted-repos-list">
-			<h2>Muted repos</h2>
-			<MutedRepos mutedRepos={mutedRepos} unmuteRepo={unmuteRepo} />
+		<div className="config-page">
+			<div className="config-section">
+				<div className="config-section__label">Muted Repos</div>
+				<p className="muted-repos-list__description">
+					Notifications from muted repos do not change the icon. Mute a repo
+					from the notification list.
+				</p>
+				<MutedRepos mutedRepos={mutedRepos} unmuteRepo={unmuteRepo} />
+			</div>
 		</div>
 	);
 }
@@ -25,39 +31,31 @@ function MutedRepos({
 }) {
 	if (mutedRepos.length === 0) {
 		return (
-			<div className="muted-repos-list__text">
-				There are no muted repos. You can mute a repo by clicking the mute
-				button next to a notification for that repo. Notifications from muted
-				repos do not change the icon.
-			</div>
+			<div className="muted-repos-list__empty">No muted repos.</div>
 		);
 	}
 	return (
-		<>
-			<div className="muted-repos-list__text">
-				These repos are muted. Notifications from muted repos do not change the
-				icon. You can unmute repos below.
-			</div>
-			<ul>
-				{mutedRepos.map(repoName => {
-					const onClick = () => {
-						unmuteRepo(repoName);
-					};
-					return (
-						<li key={repoName}>
-							{repoName} <UnmuteRepoButton onClick={onClick} />
-						</li>
-					);
-				})}
-			</ul>
-		</>
+		<ul className="muted-repos-list__repos">
+			{mutedRepos.map((repoName) => {
+				return (
+					<li key={repoName}>
+						<span className="muted-repos-list__repo-name">{repoName}</span>
+						<UnmuteRepoButton onClick={() => unmuteRepo(repoName)} />
+					</li>
+				);
+			})}
+		</ul>
 	);
 }
 
 function UnmuteRepoButton({ onClick }: { onClick: () => void }) {
 	return (
-		<button aria-label="Unmute notifications from this repo" onClick={onClick}>
-			unmute repo
+		<button
+			className="muted-repos-list__unmute-button"
+			aria-label="Unmute notifications from this repo"
+			onClick={onClick}
+		>
+			Unmute
 		</button>
 	);
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -300,8 +300,6 @@ header svg {
 	justify-content: space-between;
 }
 
-.edit-token-button,
-.edit-muted-repos-button,
 .config-button,
 .filter-button,
 .back-button {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -399,25 +399,55 @@ header svg {
 	width: 24px;
 }
 
-.muted-repos-list {
-	margin: 12px;
+.muted-repos-list__description {
+	font-size: 0.8em;
+	opacity: 0.6;
+	margin: 2px 0 8px 0;
+	line-height: 1.4;
 }
 
-.muted-repos-list h2 {
-	margin: 0 0 10px 0;
+.muted-repos-list__empty {
+	font-size: 0.85em;
+	opacity: 0.5;
+	padding: 10px;
+	border: 1px solid var(--notification-border-color);
+	border-radius: 8px;
 }
 
-.muted-repos-list ul {
+.muted-repos-list__repos {
+	border: 1px solid var(--notification-border-color);
+	border-radius: 8px;
+	overflow: hidden;
 	margin: 0;
 	padding: 0;
 }
 
-.muted-repos-list li {
+.muted-repos-list__repos li {
 	list-style-type: none;
+	padding: 8px 10px;
+	margin: 0;
+	border-bottom: 1px solid var(--notification-border-color);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
-.muted-repos-list li {
-	margin: 10px 0;
+.muted-repos-list__repos li:last-child {
+	border-bottom: none;
+}
+
+.muted-repos-list__repo-name {
+	font-size: 0.9em;
+}
+
+.muted-repos-list__unmute-button {
+	font-size: 0.85em;
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--main-link-color);
+	padding: 0;
+	flex-shrink: 0;
 }
 
 .mute-icon {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -351,6 +351,10 @@ header svg {
 	padding: 2px;
 }
 
+.attributions {
+	margin-top: auto;
+}
+
 .attributions__icon {
 	vertical-align: middle;
 	padding-right: 0.5em;
@@ -810,7 +814,7 @@ header h1 {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	justify-content: space-between;
+	justify-content: flex-start;
 }
 
 .config-page h2 {
@@ -818,7 +822,7 @@ header h1 {
 }
 
 .config-page h3 {
-	margin: 10px 0;
+	margin: 10px 0 4px 0;
 }
 
 .spinner {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -775,14 +775,34 @@ header h1 {
 	height: 150px;
 	border-top: 1px solid var(--notification-border-color);
 	overflow-y: scroll;
-	padding: 5px;
+	padding: 0;
 	margin: 0;
 }
 
 .account-list li {
 	list-style-type: none;
-	padding: 5px;
+	padding: 8px 10px;
 	margin: 0;
+	cursor: pointer;
+	border-bottom: 1px solid var(--notification-border-color);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: 0.9em;
+}
+
+.account-list li:last-child {
+	border-bottom: none;
+}
+
+.account-list li::after {
+	content: '›';
+	font-size: 1.3em;
+	opacity: 0.35;
+}
+
+.account-list li:hover {
+	background-color: var(--button-background-color);
 }
 
 .config-page {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -117,14 +117,70 @@ button {
 	margin-top: 10px;
 }
 
+.config-section__label {
+	font-size: 0.7em;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	opacity: 0.5;
+	margin: 0 0 5px 4px;
+}
+
 .config-page__settings {
+	border: 1px solid var(--notification-border-color);
+	border-radius: 8px;
+	overflow: hidden;
 	margin: 0;
 	padding: 0;
 }
 
 .config-page__settings li {
-	margin: 0 0 10px 0;
 	list-style-type: none;
+	margin: 0;
+	border-bottom: 1px solid var(--notification-border-color);
+}
+
+.config-page__settings li:last-child {
+	border-bottom: none;
+}
+
+.config-row--nav button {
+	display: flex;
+	width: 100%;
+	justify-content: space-between;
+	align-items: center;
+	padding: 8px 10px;
+	background: none;
+	border: none;
+	cursor: pointer;
+	font-size: inherit;
+	color: var(--main-text-color);
+}
+
+.config-row--nav button:hover {
+	background-color: var(--button-background-color);
+}
+
+.config-row--nav button::after {
+	content: '›';
+	font-size: 1.2em;
+	opacity: 0.35;
+}
+
+.config-row--toggle {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 8px 10px;
+	font-size: inherit;
+}
+
+.config-row--toggle label {
+	cursor: pointer;
+}
+
+.config-row--toggle input[type='checkbox'] {
+	margin: 0;
 }
 
 a {
@@ -364,10 +420,6 @@ header svg {
 	fill: var(--config-action-text-color);
 }
 
-.config-page__settings input[type='checkbox'] {
-	margin-right: 0.5em;
-	vertical-align: -2px;
-}
 
 header h1 {
 	font-size: 1.4em;
@@ -815,9 +867,6 @@ header h1 {
 	justify-content: flex-start;
 }
 
-.config-page h2 {
-	margin: 0;
-}
 
 .config-page h3 {
 	margin: 10px 0 4px 0;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -118,12 +118,38 @@ button {
 }
 
 .config-section__label {
-	font-size: 0.7em;
+	font-size: 1em;
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	opacity: 0.5;
 	margin: 0 0 5px 4px;
+}
+
+.config-section__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	margin-bottom: 5px;
+}
+
+.config-section__header .config-section__label {
+	margin-bottom: 0;
+}
+
+.config-section__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.config-section__action-button {
+	font-size: 1em;
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--main-link-color);
+	padding: 0;
 }
 
 .config-page__settings {
@@ -702,12 +728,6 @@ header h1 {
 	gap: 10px;
 }
 
-.account-page-header {
-	display: flex;
-	width: 100%;
-	justify-content: space-between;
-	margin-bottom: 10px;
-}
 
 .no-notifications {
 	padding: 12px;
@@ -826,9 +846,10 @@ header h1 {
 }
 
 .account-list {
-	height: 150px;
-	border-top: 1px solid var(--notification-border-color);
-	overflow-y: scroll;
+	border: 1px solid var(--notification-border-color);
+	border-radius: 8px;
+	overflow-y: auto;
+	max-height: 220px;
 	padding: 0;
 	margin: 0;
 }
@@ -842,7 +863,6 @@ header h1 {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	font-size: 0.9em;
 }
 
 .account-list li:last-child {
@@ -851,12 +871,29 @@ header h1 {
 
 .account-list li::after {
 	content: '›';
-	font-size: 1.3em;
+	font-size: 1.2em;
 	opacity: 0.35;
+	flex-shrink: 0;
+	margin-left: 8px;
 }
 
 .account-list li:hover {
 	background-color: var(--button-background-color);
+}
+
+.account-list__info {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.account-list__name {
+	font-size: 0.9em;
+}
+
+.account-list__url {
+	font-size: 0.75em;
+	opacity: 0.6;
 }
 
 .config-page {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -362,8 +362,9 @@ header svg {
 	fill: var(--config-action-text-color);
 }
 
-.auto-load-setting {
+.config-page__settings input[type='checkbox'] {
 	margin-right: 0.5em;
+	vertical-align: -2px;
 }
 
 header h1 {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -175,10 +175,16 @@ header svg {
 	justify-content: flex-end;
 	align-items: center;
 	font-size: 0.7em;
+	gap: 8px;
 }
 
 .filter-label {
-	margin-bottom: 2px;
+	color: #fff;
+	cursor: pointer;
+}
+
+.filter-button__area--active .filter-button svg {
+	fill: var(--main-link-color);
 }
 
 .header__primary a,
@@ -214,7 +220,9 @@ header svg {
 	font-size: 0.8em;
 	border-radius: 16px;
 	opacity: 0.6;
-	transition: background 0.15s ease, opacity 0.15s ease;
+	transition:
+		background 0.15s ease,
+		opacity 0.15s ease;
 }
 
 .read-status-toggle__button--active {


### PR DESCRIPTION
## Summary

- **Filter button**: add spacing between active filter label and icon; highlight active filter state with a pill badge and accent-colored icon
- **Settings page**: redesign as a grouped native-style panel — `config-section` container with rounded-border grouped list, navigation rows with disclosure chevrons, toggle rows with label-left/checkbox-right layout, small uppercase section labels; remove redundant "Configuration" H2
- **Account list**: same grouped panel treatment — section label + inline "+ New" action button, two-line rows (name + muted URL), consistent bordered container replacing fixed-height scroll box
- **Muted repos list**: same pattern — section label, description text, bordered list with repo name and inline "Unmute" link action, styled empty state
- **Shared CSS utilities**: `config-section__label`, `config-section__header`, `config-section__actions`, `config-section__action-button`, `config-row--nav`, `config-row--toggle` for consistent reuse across all settings-style pages

## Test plan

- [ ] Open settings page — verify grouped list renders correctly, nav rows navigate to accounts/muted repos, checkboxes toggle correctly and stay right-aligned
- [ ] Open accounts page — verify account rows show name + URL, "+ New" creates a new account, "Restore" appears after deleting an account
- [ ] Open muted repos page — verify list renders with unmute buttons; verify empty state shows when no repos are muted; verify unmute removes a repo
- [ ] Toggle a notification filter — verify label pill and accent icon appear; verify clearing filter removes them
- [ ] Check dark mode for all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)