### PR TITLE
Add persistent notice for accounts with fetch errors

### DIFF
--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -104,6 +104,7 @@ export default function Header({
 					fetchInterval={fetchInterval}
 				/>
 			)}
+			{!isTokenInvalid && !offline && <FetchErrorNotice />}
 			{children}
 		</header>
 	);
@@ -184,6 +185,28 @@ function InvalidTokenNotice() {
 			<span>
 				Some of your accounts are not working: '{accountNames}'. Please
 				double-check your info!
+			</span>
+		</div>
+	);
+}
+
+function FetchErrorNotice() {
+	const accounts = useSelector((state: AppReduxState) => state.accounts);
+	const accountsWithFetchErrors = useSelector(
+		(state: AppReduxState) => state.accountsWithFetchErrors
+	);
+	const failingAccounts = accounts.filter((account) =>
+		accountsWithFetchErrors.includes(account.id)
+	);
+	if (failingAccounts.length === 0) {
+		return null;
+	}
+	const accountNames = failingAccounts.map((account) => account.name).join(', ');
+	return (
+		<div className="offline-notice">
+			<span>
+				Could not fetch notifications for: '{accountNames}'. Check your
+				connection or proxy settings.
 			</span>
 		</div>
 	);

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -16,6 +16,7 @@ import {
 	fetchDone,
 	gotNotes,
 	addConnectionError,
+	addAccountFetchError,
 	setIsTokenInvalid,
 } from '../lib/reducer';
 import {
@@ -316,6 +317,7 @@ function dispatchAccountFetchError(
 	account: AccountInfo,
 	err: FetchErrorObject
 ) {
+	dispatch(addAccountFetchError(account.id));
 	if (typeof err === 'object' && isTokenInvalid(err)) {
 		const message = `Token is invalid for account "${account.name}"`;
 		debug(message);

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -13,6 +13,7 @@ import {
 	ActionChangeToOffline,
 	ActionGotNotes,
 	ActionAddConnectionError,
+	ActionAddAccountFetchError,
 	ActionFetchBegin,
 	ActionFetchEnd,
 	ActionMarkAllNotesSeen,
@@ -36,6 +37,7 @@ const initialState: AppReduxState = {
 	token: undefined,
 	notes: [],
 	errors: [],
+	accountsWithFetchErrors: [],
 	mutedRepos: [],
 	fetchingInProgress: false,
 	lastChecked: false,
@@ -117,6 +119,15 @@ export function createReducer() {
 					errors: [...state.errors, action.error],
 					lastChecked: Date.now(),
 				});
+			case 'ADD_ACCOUNT_FETCH_ERROR':
+				return {
+					...state,
+					accountsWithFetchErrors: state.accountsWithFetchErrors.includes(
+						action.accountId
+					)
+						? state.accountsWithFetchErrors
+						: [...state.accountsWithFetchErrors, action.accountId],
+				};
 			case 'CLEAR_ERRORS':
 				return Object.assign({}, state, { errors: [] });
 			case 'MARK_NOTE_UNREAD': {
@@ -229,6 +240,7 @@ export function createReducer() {
 					lastSuccessfulCheck: Date.now(),
 					fetchRetryCount: 0,
 					errors: [],
+					accountsWithFetchErrors: [],
 					fetchInterval: defaultFetchInterval,
 					notes: allNotes,
 					locallyUnreadNotes: updatedLocallyUnread,
@@ -321,6 +333,12 @@ export function gotNotes(notes: Note[]): ActionGotNotes {
 
 export function addConnectionError(error: string): ActionAddConnectionError {
 	return { type: 'ADD_CONNECTION_ERROR', error };
+}
+
+export function addAccountFetchError(
+	accountId: string
+): ActionAddAccountFetchError {
+	return { type: 'ADD_ACCOUNT_FETCH_ERROR', accountId };
 }
 
 export function fetchBegin(): ActionFetchBegin {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -500,7 +500,7 @@ header h1 {
 
 .offline-notice {
 	width: 100%;
-	padding: 4px 5px;
+	padding: 4px 12px;
 	background-color: var(--offline-notice-background-color);
 	font-size: 0.9em;
 	position: fixed;

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -21,6 +21,7 @@ export interface AppReduxState {
 	token: undefined | string;
 	notes: Note[];
 	errors: string[];
+	accountsWithFetchErrors: string[];
 	mutedRepos: string[];
 	fetchingInProgress: boolean;
 	lastChecked: false | number;
@@ -80,6 +81,10 @@ export type ActionAddConnectionError = {
 	type: 'ADD_CONNECTION_ERROR';
 	error: string;
 };
+export type ActionAddAccountFetchError = {
+	type: 'ADD_ACCOUNT_FETCH_ERROR';
+	accountId: string;
+};
 export type ActionFetchBegin = { type: 'FETCH_BEGIN' };
 export type ActionFetchEnd = { type: 'FETCH_END' };
 export type ActionFetchNotifications = { type: 'GITNEWS_FETCH_NOTIFICATIONS' };
@@ -121,6 +126,7 @@ export type AppReduxAction =
 	| ActionChangeToOffline
 	| ActionGotNotes
 	| ActionAddConnectionError
+	| ActionAddAccountFetchError
 	| ActionFetchBegin
 	| ActionFetchEnd
 	| ActionFetchNotifications


### PR DESCRIPTION
## Summary

- Adds a persistent `FetchErrorNotice` banner in the header that shows which accounts are failing to fetch notifications (e.g. due to bad proxy settings or network issues)
- Unlike the dismissible error message area, this banner persists even after errors are cleared — it only goes away once the account successfully fetches again
- Tracks failing accounts via a new `accountsWithFetchErrors: string[]` in Redux state, cleared on successful fetch (`NOTES_RETRIEVED`) but not on `CLEAR_ERRORS`
- Also increases horizontal padding on `.offline-notice` from `5px` to `12px` so the text has a bit more breathing room from the window edges

## How it works

When `dispatchAccountFetchError` fires for a failing account, it now dispatches both the existing `ADD_CONNECTION_ERROR` (for the dismissible message) and a new `ADD_ACCOUNT_FETCH_ERROR` action (for the persistent banner). The banner reads account names from the store and renders a notice styled consistently with the existing offline/invalid-token notices.

## Test plan

- [ ] Verify that with a misconfigured account, the persistent banner appears naming the failing account
- [ ] Verify that clicking "Clear Errors" dismisses the error text but leaves the persistent banner visible
- [ ] Verify that the banner disappears after the account fetches successfully
- [ ] Verify the notice has comfortable horizontal padding (not hugging the window edges)
- [ ] `yarn test` — all tests pass
- [ ] `yarn typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)