### PR TITLE
Add Draft status icon when referenced PR is a draft

### DIFF
--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -192,6 +192,7 @@ async function getCommentDataForNotification(
 interface SubjectData {
 	noteState: string;
 	noteMerged: boolean;
+	noteDraft: boolean;
 	subjectHtmlUrl: string;
 }
 
@@ -202,9 +203,10 @@ async function getSubjectDataForNotification(
 ): Promise<SubjectData> {
 	let noteState: string = '';
 	let noteMerged: boolean = false;
+	let noteDraft: boolean = false;
 	let subjectHtmlUrl: string = '';
 	if (!notification.subject.url) {
-		return { noteState, noteMerged, subjectHtmlUrl };
+		return { noteState, noteMerged, noteDraft, subjectHtmlUrl };
 	}
 	const subjectPath = getOctokitRequestPathFromUrl(
 		account,
@@ -214,6 +216,7 @@ async function getSubjectDataForNotification(
 		const subject = await octokit.request(`GET ${subjectPath}`, {});
 		noteState = subject.data.state;
 		noteMerged = subject.data.merged;
+		noteDraft = subject.data.draft ?? false;
 		subjectHtmlUrl = subject.data.html_url;
 	} catch (error) {
 		logMessage(
@@ -224,6 +227,7 @@ async function getSubjectDataForNotification(
 	return {
 		noteState,
 		noteMerged,
+		noteDraft,
 		subjectHtmlUrl,
 	};
 }
@@ -256,7 +260,7 @@ function buildNoteFromData({
 			commentData.commentAvatar ?? notification.repository.owner.avatar_url,
 		repositoryOwnerAvatar: notification.repository.owner.avatar_url,
 		api: {
-			subject: { state: subjectData.noteState, merged: subjectData.noteMerged },
+			subject: { state: subjectData.noteState, merged: subjectData.noteMerged, draft: subjectData.noteDraft },
 			notification: { reason: notification.reason as NoteReason },
 		},
 	};

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -116,12 +116,18 @@ export default function Notification({
 		note.api.subject.state &&
 		note.api.subject.state === 'closed';
 	const isMerged = note.api.subject && note.api.subject.merged;
+	const isDraft =
+		note.type === 'PullRequest' &&
+		!isMerged &&
+		!isClosed &&
+		note.api.subject?.draft === true;
 	const iconType = isMerged || isClosed ? 'checkmark-circle' : 'chat';
-	const iconText = isMerged || isClosed ? 'closed' : 'open';
+	const iconText = isMerged || isClosed ? 'closed' : isDraft ? 'draft' : 'open';
 	const iconClasses = [
 		'notification__type',
 		...(isClosed && !isMerged ? ['notification__type--closed'] : []),
 		...(isMerged ? ['notification__type--merged'] : []),
+		...(isDraft ? ['notification__type--draft'] : []),
 	];
 
 	const doMute = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -621,6 +621,10 @@ header h1 {
 	fill: #8957e5;
 }
 
+.notification__type--draft {
+	fill: #848d97;
+}
+
 .notification__type svg {
 	width: 16px;
 	height: 16px;

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -14,7 +14,7 @@ export type NoteReason =
 	| 'your_activity';
 
 export interface NoteApi {
-	subject?: { state?: string; merged?: boolean };
+	subject?: { state?: string; merged?: boolean; draft?: boolean };
 	notification?: { reason?: NoteReason };
 }
 


### PR DESCRIPTION
This replaces the "Open" text for a note with "Draft" if the referenced PR is a draft.
