### PR TITLE
Mark note read when unsubscribing

### DIFF
--- a/src/renderer/lib/github-middleware.ts
+++ b/src/renderer/lib/github-middleware.ts
@@ -50,6 +50,7 @@ export function createGitHubMiddleware(): Middleware<unknown, AppReduxState> {
 					);
 					return;
 				}
+				markNoteRead(action.note, account);
 				unsubscribeNote(action.note, account);
 				break;
 			}


### PR DESCRIPTION
This fixes a bug in #225 where notifications would reappear on the next fetch after unsubscribing.