### PR TITLE
Always show "last checked" in addition to "Unread" toggle

### DIFF
--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -92,7 +92,6 @@ export default function Header({
 			<SecondaryHeader
 				fetchingInProgress={fetchingInProgress}
 				lastSuccessfulCheck={lastSuccessfulCheck}
-				currentPane={currentPane}
 				showUnreadOnly={showUnreadOnly}
 				setShowUnreadOnly={setShowUnreadOnly}
 			/>
@@ -113,37 +112,26 @@ export default function Header({
 function SecondaryHeader({
 	lastSuccessfulCheck,
 	fetchingInProgress,
-	currentPane,
 	showUnreadOnly,
 	setShowUnreadOnly,
 }: {
 	lastSuccessfulCheck: false | number;
 	fetchingInProgress: boolean;
-	currentPane: AppPane;
 	showUnreadOnly: boolean;
 	setShowUnreadOnly: (value: boolean) => void;
 }) {
-	if (fetchingInProgress) {
-		return (
-			<div className="header__secondary">
-				<FetchingInProgress />
-			</div>
-		);
-	}
-	if (currentPane === PANE_NOTIFICATIONS) {
-		return (
-			<div className="header__secondary">
-				<ReadStatusToggle
-					showUnreadOnly={showUnreadOnly}
-					setShowUnreadOnly={setShowUnreadOnly}
-				/>
-			</div>
-		);
-	}
 	return (
 		<div className="header__secondary">
-			{lastSuccessfulCheck && (
-				<UpdatingLastChecked lastSuccessfulCheck={lastSuccessfulCheck} />
+			<ReadStatusToggle
+				showUnreadOnly={showUnreadOnly}
+				setShowUnreadOnly={setShowUnreadOnly}
+			/>
+			{fetchingInProgress ? (
+				<FetchingInProgress />
+			) : (
+				lastSuccessfulCheck && (
+					<UpdatingLastChecked lastSuccessfulCheck={lastSuccessfulCheck} />
+				)
 			)}
 		</div>
 	);
@@ -201,7 +189,9 @@ function FetchErrorNotice() {
 	if (failingAccounts.length === 0) {
 		return null;
 	}
-	const accountNames = failingAccounts.map((account) => account.name).join(', ');
+	const accountNames = failingAccounts
+		.map((account) => account.name)
+		.join(', ');
 	return (
 		<div className="offline-notice">
 			<span>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -279,10 +279,11 @@ header svg {
 .header__secondary {
 	margin: 0 10px 10px 10px;
 	width: 100%;
-	height: 28px;
 	display: flex;
+	flex-direction: column;
 	justify-content: center;
 	align-items: center;
+	gap: 4px;
 }
 
 .read-status-toggle {


### PR DESCRIPTION
This PR makes sure that we always display the "last checked" text in the header. It used to always be displayed but was replaced by the "All/Unread" toggle in #228 . Now both will always be shown.
