### PR TITLE
Support a server returning HTML instead of data

### DIFF
--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -8,6 +8,7 @@ import {
 	getErrorMessage,
 	isGitHubOffline,
 	isInvalidJson,
+	isServerReturningHtml,
 	isTokenInvalid,
 } from '../lib/helpers';
 import {
@@ -323,6 +324,12 @@ function dispatchAccountFetchError(
 		debug(message);
 		window.electronApi.logMessage(message, 'warn');
 		dispatch(setIsTokenInvalid(err.accountId ?? account.id, true));
+		return;
+	}
+	if (isServerReturningHtml(err as UnknownFetchError)) {
+		const message = `GitHub Enterprise server for "${account.name}" is temporarily unavailable (server may be starting up)`;
+		debug(message);
+		window.electronApi.logMessage(message, 'warn');
 		return;
 	}
 	const message = `Error fetching notifications for "${account.name}": ${getErrorMessage(err as UnknownFetchError)}`;

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -141,6 +141,14 @@ export function isInvalidJson(error: UnknownFetchError): boolean {
 	return typeof error === 'object' && error.type === 'invalid-json';
 }
 
+export function isServerReturningHtml(error: UnknownFetchError): boolean {
+	return (
+		typeof error === 'object' &&
+		typeof error.message === 'string' &&
+		error.message.includes('<!DOCTYPE')
+	);
+}
+
 export function getSecondsUntilNextFetch(
 	lastChecked: number | false,
 	fetchInterval: number


### PR DESCRIPTION
If the remote server returns a bunch of HTML instead of data when listing or fetching notifications, that means the server is unavailable. We should treat this as a "normal" error and not show the full HTML in the error section.