### PR TITLE
Fix bugs opening notifications with invalid URLs

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -128,11 +128,13 @@ ipcMain.on('set-icon', (_event, arg: unknown) => {
 
 ipcMain.on('open-url', (_event, url: unknown, options) => {
 	logMessage(`Opening url: ${url}`, 'info');
-	if (typeof url !== 'string') {
+	if (typeof url !== 'string' || !url) {
 		logMessage('Failed to open URL: it is invalid', 'error');
 		return;
 	}
-	shell.openExternal(url, options);
+	shell.openExternal(url, options).catch((error) => {
+		logMessage(`Failed to open URL ${url}: ${error}`, 'error');
+	});
 });
 
 ipcMain.on('quit-app', () => {

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -64,7 +64,7 @@ export default function Notification({
 			return;
 		}
 		markRead(token, note);
-		openUrl(note.commentUrl);
+		openUrl(note.commentUrl || note.subjectUrl);
 	};
 
 	const onClickMarkRead = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/src/renderer/components/notifications-area.tsx
+++ b/src/renderer/components/notifications-area.tsx
@@ -105,7 +105,7 @@ export default function NotificationsArea({
 			switch (action) {
 				case 'open':
 					markRead(token, note);
-					openUrl(note.commentUrl);
+					openUrl(note.commentUrl || note.subjectUrl);
 					break;
 				case 'markRead':
 					markRead(token, note);


### PR DESCRIPTION
Certain notification types (invitations, repository notifications, etc.) have no latest comment, so `commentHtmlUrl` stays as '' (empty string) after enrichment. That causes an unhandled error like `Error: Invalid URL
at IpcMainlmpl.<anonymous>` when you try to open that URL. `subjectUrl` is the PR/issue URL and is a better fallback.

- **Prevent trying to open empty urls and log when an external URL fails**
- **Use subjectUrl as fallback for commentUrl**

Props to @alshakero who was able to reproduce this long-standing bug.