### PR TITLE
Better handle broken notes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -126,15 +126,20 @@ ipcMain.on('set-icon', (_event, arg: unknown) => {
 	setIcon(arg);
 });
 
-ipcMain.on('open-url', (_event, url: unknown, options) => {
+ipcMain.handle('open-url', async (_event, url: unknown, options) => {
 	logMessage(`Opening url: ${url}`, 'info');
 	if (typeof url !== 'string' || !url) {
 		logMessage('Failed to open URL: it is invalid', 'error');
-		return;
+		return { error: 'Failed to open URL: it is invalid' };
 	}
-	shell.openExternal(url, options).catch((error) => {
-		logMessage(`Failed to open URL ${url}: ${error}`, 'error');
-	});
+	try {
+		await shell.openExternal(url, options);
+		return;
+	} catch (error) {
+		const message = `Failed to open URL: ${error}`;
+		logMessage(message, 'error');
+		return { error: message };
+	}
 });
 
 ipcMain.on('quit-app', () => {

--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -194,6 +194,7 @@ interface SubjectData {
 	noteMerged: boolean;
 	noteDraft: boolean;
 	subjectHtmlUrl: string;
+	failed?: boolean;
 }
 
 async function getSubjectDataForNotification(
@@ -223,6 +224,7 @@ async function getSubjectDataForNotification(
 			`Failed to fetch subject for ${subjectPath} (${notification.subject.url})`,
 			'error'
 		);
+		return { noteState, noteMerged, noteDraft, subjectHtmlUrl, failed: true };
 	}
 	return {
 		noteState,
@@ -259,6 +261,7 @@ function buildNoteFromData({
 		commentAvatar:
 			commentData.commentAvatar ?? notification.repository.owner.avatar_url,
 		repositoryOwnerAvatar: notification.repository.owner.avatar_url,
+		gitnewsIsInvalid: subjectData.failed === true,
 		api: {
 			subject: { state: subjectData.noteState, merged: subjectData.noteMerged, draft: subjectData.noteDraft },
 			notification: { reason: notification.reason as NoteReason },

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -15,7 +15,7 @@ const bridge: MainBridge = {
 		ipcRenderer.send('log-message', message, level),
 	toggleAutoLaunch: (isEnabled: boolean) =>
 		ipcRenderer.send('toggle-auto-launch', isEnabled),
-	openUrl: (url: string) => ipcRenderer.send('open-url', url),
+	openUrl: (url: string) => ipcRenderer.invoke('open-url', url),
 	setIcon: (nextIcon: IconType) => ipcRenderer.send('set-icon', nextIcon),
 	onHide: (callback: () => void) => ipcRenderer.on('hide-app', callback),
 	onShow: (callback: () => void) => ipcRenderer.on('show-app', callback),

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -63,8 +63,7 @@ export default function Notification({
 			queueNoteAction(note, 'open');
 			return;
 		}
-		markRead(token, note);
-		openUrl(note.commentUrl || note.subjectUrl);
+		openUrl(note.commentUrl || note.subjectUrl, { token, note });
 	};
 
 	const onClickMarkRead = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -95,6 +95,7 @@ export default function Notification({
 	const lastUpdated = new Date(note.updatedAt);
 	const timeString = formatDistanceToNow(lastUpdated, { addSuffix: true });
 	const isMention = note.api.notification?.reason === 'mention';
+	const isInvalid = note.gitnewsIsInvalid === true;
 	const noteClasses = [
 		'notification',
 		...(isMultiOpenMode && !queuedAction ? ['notification--multi-open'] : []),
@@ -105,7 +106,7 @@ export default function Notification({
 		...(queuedAction === 'markUnread'
 			? ['notification--multi-mark-unread-clicked']
 			: []),
-		...getNoteClasses({ isUnread, isMuted }),
+		...getNoteClasses({ isUnread, isMuted, isInvalid }),
 	];
 	const defaultAvatar = `https://avatars.io/twitter/${note.repositoryFullName}`;
 	const avatarSrc =
@@ -232,6 +233,11 @@ export default function Notification({
 						</span>
 					</div>
 					<div className="notification__title">{note.title}</div>
+					{isInvalid && (
+						<div className="notification__invalid-notice">
+							⚠ Failed to load details
+						</div>
+					)}
 					<div className="notification__footer">
 						<span className="notification__time">{timeString}</span>
 						<span className="notification__actions">
@@ -390,12 +396,17 @@ function UnsubscribeButton({
 function getNoteClasses({
 	isMuted,
 	isUnread,
+	isInvalid,
 }: {
 	isMuted?: boolean;
 	isUnread?: boolean;
+	isInvalid?: boolean;
 }) {
 	if (isMuted) {
 		return ['notification__muted'];
+	}
+	if (isInvalid) {
+		return ['notification__invalid'];
 	}
 	if (isUnread) {
 		return ['notification__unread'];

--- a/src/renderer/components/notifications-area.tsx
+++ b/src/renderer/components/notifications-area.tsx
@@ -124,7 +124,7 @@ export default function NotificationsArea({
 	}, []);
 	const onKeyDown = React.useCallback(
 		(event: KeyboardEvent) => {
-			if (event.code.includes('Meta')) {
+			if (event.code.includes('Meta') && !event.shiftKey) {
 				setMultiOpenMode(true);
 			}
 		},

--- a/src/renderer/components/notifications-area.tsx
+++ b/src/renderer/components/notifications-area.tsx
@@ -104,8 +104,7 @@ export default function NotificationsArea({
 		queuedNotes.forEach(({ note, action }) => {
 			switch (action) {
 				case 'open':
-					markRead(token, note);
-					openUrl(note.commentUrl || note.subjectUrl);
+					openUrl(note.commentUrl || note.subjectUrl, { token, note });
 					break;
 				case 'markRead':
 					markRead(token, note);

--- a/src/renderer/lib/electron-middleware.ts
+++ b/src/renderer/lib/electron-middleware.ts
@@ -2,10 +2,6 @@ import { Middleware } from 'redux';
 import { AppReduxState, IconType } from '../types';
 import { isAction } from './helpers';
 
-function openUrl(url: string) {
-	window.electronApi.openUrl(url);
-}
-
 function setIcon(nextIcon: IconType) {
 	window.electronApi.setIcon(nextIcon);
 }
@@ -15,7 +11,7 @@ function scrollToTopNotification() {
 }
 
 export const electronMiddleware: Middleware<unknown, AppReduxState> =
-	() => (next) => (action) => {
+	(store) => (next) => (action) => {
 		if (!isAction(action)) {
 			throw new Error(
 				'Invalid action dispatched in electron: ' + JSON.stringify(action)
@@ -23,7 +19,18 @@ export const electronMiddleware: Middleware<unknown, AppReduxState> =
 		}
 		switch (action.type) {
 			case 'OPEN_URL':
-				return openUrl(action.url);
+				window.electronApi.openUrl(action.url).then((result) => {
+					if (result?.error) {
+						store.dispatch({
+							type: 'ADD_CONNECTION_ERROR',
+							error: result.error,
+						});
+					} else if (action.noteToMarkRead) {
+						const { token, note } = action.noteToMarkRead;
+						store.dispatch({ type: 'MARK_NOTE_READ', token, note });
+					}
+				});
+				return;
 			case 'SET_ICON':
 				return setIcon(action.icon);
 			case 'SCROLL_TO_TOP':

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -353,8 +353,11 @@ export function fetchNotifications() {
 	return { type: 'GITNEWS_FETCH_NOTIFICATIONS' };
 }
 
-export function openUrl(url: string) {
-	return { type: 'OPEN_URL', url };
+export function openUrl(
+	url: string,
+	noteToMarkRead?: { token: string; note: Note }
+) {
+	return { type: 'OPEN_URL', url, noteToMarkRead };
 }
 
 export function setIcon(icon: string) {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -585,6 +585,17 @@ header h1 {
 	position: relative;
 }
 
+.notification__invalid {
+	border-left: 4px solid #d97706;
+	opacity: 0.75;
+}
+
+.notification__invalid-notice {
+	font-size: 0.75em;
+	color: #d97706;
+	margin-top: 2px;
+}
+
 .notification__unread {
 	background-color: var(--notification-unread-background-color);
 }

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -91,7 +91,8 @@ export type ActionFetchNotifications = { type: 'GITNEWS_FETCH_NOTIFICATIONS' };
 export type ActionOpenUrl = {
 	type: 'OPEN_URL';
 	url: string;
-	options: Electron.OpenExternalOptions;
+	options?: Electron.OpenExternalOptions;
+	noteToMarkRead?: { token: string; note: Note };
 };
 export type ActionSetIcon = { type: 'SET_ICON'; icon: IconType };
 export type ActionChangeAutoLoad = {
@@ -142,7 +143,7 @@ export type AppReduxAction =
 	| ActionToggleTokenInvalid
 	| ActionToggleLogging;
 
-export type OpenUrl = (url: string) => void;
+export type OpenUrl = (url: string, noteToMarkRead?: { token: string; note: Note }) => void;
 
 export type MarkRead = (token: string, note: Note) => void;
 
@@ -172,7 +173,7 @@ export interface MainBridge {
 	logMessage: (message: string, level: 'info' | 'warn' | 'error') => void;
 	toggleLogging: (isLogging: boolean) => void;
 	toggleAutoLaunch: (isEnabled: boolean) => void;
-	openUrl: OpenUrl;
+	openUrl: (url: string) => Promise<{ error: string } | undefined>;
 	setIcon: (nextIcon: IconType) => void;
 	onHide: (callback: () => void) => void;
 	onShow: (callback: () => void) => void;

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -26,6 +26,7 @@ export interface Note {
 	repositoryFullName: string;
 	gitnewsMarkedUnread?: boolean;
 	gitnewsSeen?: boolean;
+	gitnewsIsInvalid?: boolean;
 
 	/**
 	 * Number of milliseconds since the epoc (what Date.now() returns).


### PR DESCRIPTION
This PR makes a few changes to better handle the case when notes load in a broken state (eg: if there's a network failure after fetching the note but before fetching the note's subject details).

Previously if a note partially fails to load, it would show as normal but clicking on it would seem to do nothing except mark the note as read. This is very bad UX.

After this change the note itself will appear with a warning label and clicking on it will show an error. It will also fail to mark the note as read.

- **Show error if opening URL fails and do not mark as read**
- **Highlight broken notes**

<img width="432" height="99" alt="Screenshot 2026-04-04 at 2 21 57 PM" src="https://github.com/user-attachments/assets/1c63f4cd-5ae9-49fa-adbe-c14f3fd3809c" />

<img width="423" height="132" alt="Screenshot 2026-04-04 at 2 25 32 PM" src="https://github.com/user-attachments/assets/08500a0d-f5e9-404d-be86-fc75dc67be66" />
