### PR TITLE
Add badge when note was recently opened

### DIFF
--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -136,7 +136,7 @@ class App extends React.Component<AppProps, AppState> {
 	}
 
 	getReadNotifications() {
-		return this.props.notes.filter((note) => {
+		const notes = this.props.notes.filter((note) => {
 			if (!note.unread && !note.gitnewsMarkedUnread) {
 				return true;
 			}
@@ -148,6 +148,9 @@ class App extends React.Component<AppProps, AppState> {
 			}
 			return false;
 		});
+		return notes.sort(
+			(a, b) => (b.gitnewsOpenedAt ?? 0) - (a.gitnewsOpenedAt ?? 0)
+		);
 	}
 
 	getUnreadNotifications() {

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -94,6 +94,12 @@ export default function Notification({
 
 	const lastUpdated = new Date(note.updatedAt);
 	const timeString = formatDistanceToNow(lastUpdated, { addSuffix: true });
+	const RECENTLY_OPENED_MS = 30 * 60 * 1000; // 30 minutes
+	const openedRecentlyAt =
+		note.gitnewsOpenedAt &&
+		Date.now() - note.gitnewsOpenedAt < RECENTLY_OPENED_MS
+			? note.gitnewsOpenedAt
+			: null;
 	const isMention = note.api.notification?.reason === 'mention';
 	const isInvalid = note.gitnewsIsInvalid === true;
 	const noteClasses = [
@@ -258,6 +264,14 @@ export default function Notification({
 							/>
 						</span>
 					</div>
+					{openedRecentlyAt && (
+						<div className="notification__opened-recently">
+							{"opened "}
+							{formatDistanceToNow(new Date(openedRecentlyAt), {
+								addSuffix: true,
+							})}
+						</div>
+					)}
 				</div>
 			</div>
 			<div

--- a/src/renderer/lib/helpers.ts
+++ b/src/renderer/lib/helpers.ts
@@ -63,12 +63,18 @@ export function mergeNotifications(
 				...note,
 				gitnewsSeen: previousNote.gitnewsSeen,
 				gitnewsMarkedUnread: previousNote.gitnewsMarkedUnread,
+				gitnewsOpenedAt: previousNote.gitnewsOpenedAt,
 				// Preserve local "mark as read" action if the note hasn't been updated.
 				// This prevents a race condition where marking a note as read locally
 				// gets overwritten by a fetch that completes before the API call to
 				// GitHub finishes.
 				unread: previousNote.unread === false ? false : note.unread,
 			};
+		}
+		// Always preserve gitnewsOpenedAt even when the note has new GitHub activity,
+		// since it tracks when the user last opened the note in Gitnews.
+		if (previousNote?.gitnewsOpenedAt) {
+			return { ...note, gitnewsOpenedAt: previousNote.gitnewsOpenedAt };
 		}
 		return note;
 	});

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -152,7 +152,12 @@ export function createReducer() {
 					...state,
 					notes: state.notes.map((note) =>
 						getNoteId(note) === noteId
-							? { ...note, unread: false, gitnewsMarkedUnread: false }
+							? {
+									...note,
+									unread: false,
+									gitnewsMarkedUnread: false,
+									gitnewsOpenedAt: Date.now(),
+								}
 							: note
 					),
 					locallyUnreadNotes: (state.locallyUnreadNotes ?? []).filter(

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -659,6 +659,11 @@ header h1 {
 	color: var(--notification-timestamp-color);
 }
 
+.notification__opened-recently {
+	font-size: 0.7em;
+	color: #3b82f6;
+}
+
 .notification__mute-confirm__text {
 	text-align: center;
 	font-size: 0.9em;

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -33,6 +33,12 @@ export interface Note {
 	 */
 	gitnewsSeenAt?: number;
 
+	/**
+	 * Number of milliseconds since the epoc (what Date.now() returns).
+	 * Set when the user opens or manually marks the note as read in Gitnews.
+	 */
+	gitnewsOpenedAt?: number;
+
 	api: NoteApi;
 	commentUrl: string;
 


### PR DESCRIPTION
When a user clicks a notification to open it in the browser, it gets marked as read and moves to the read list. If something then goes wrong — the URL opened in a browser profile without access, the browser crashed — there's no easy way to identify which notification they just tried to open. The note is somewhere in the read list with no indication of when it was last interacted with.

This PR adds a badge to the bottom of notes after they have been recently opened or marked as read. It also sorts these notifications to the top of the read list to make them easier to find.

<img width="426" height="199" alt="Screenshot 2026-04-04 at 3 28 54 PM" src="https://github.com/user-attachments/assets/0c3e58d3-0b97-4d1e-8618-a8df102c515b" />
