### PR TITLE
Skip re-hydration of notes which have not changed

### DIFF
--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -240,6 +240,11 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 						existing.updatedAt === basicNote.updatedAt &&
 						!existing.gitnewsIsInvalid
 					) {
+						debug(
+							'Reusing cached hydration for note %s (updatedAt: %s)',
+							basicNote.id,
+							basicNote.updatedAt
+						);
 						allNotes.push({
 							...existing,
 							unread: basicNote.unread,

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -224,15 +224,42 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 					return doesBasicNoteMatchFilter(note, state.filterType);
 				});
 
+				// Phase 2.5 — Skip re-hydration for notes whose updatedAt hasn't changed
+				const existingNotesByKey = new Map<string, Note>();
+				for (const note of state.notes) {
+					existingNotesByKey.set(note.gitnewsAccountId + note.id, note);
+				}
+
+				const allNotes: Note[] = [];
+				const needsHydration: BasicNote[] = [];
+				for (const basicNote of toEnrich) {
+					const key = basicNote.gitnewsAccountId + basicNote.id;
+					const existing = existingNotesByKey.get(key);
+					if (
+						existing &&
+						existing.updatedAt === basicNote.updatedAt &&
+						!existing.gitnewsIsInvalid
+					) {
+						allNotes.push({
+							...existing,
+							unread: basicNote.unread,
+							api: {
+								...existing.api,
+								notification: { reason: basicNote.reason },
+							},
+						});
+					} else {
+						needsHydration.push(basicNote);
+					}
+				}
+
 				// Phase 3 — Enrich (grouped by account)
 				const byAccount = new Map<string, BasicNote[]>();
-				for (const note of toEnrich) {
+				for (const note of needsHydration) {
 					const group = byAccount.get(note.gitnewsAccountId) ?? [];
 					group.push(note);
 					byAccount.set(note.gitnewsAccountId, group);
 				}
-
-				const allNotes: Note[] = [];
 				const phase3Errors: AccountError[] = [];
 				await Promise.all(
 					[...byAccount.entries()].map(([accountId, notes]) => {

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -241,9 +241,11 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 						!existing.gitnewsIsInvalid
 					) {
 						debug(
-							'Reusing cached hydration for note %s (updatedAt: %s)',
-							basicNote.id,
-							basicNote.updatedAt
+							`Reusing cached hydration for note ${basicNote.id} (updatedAt: ${basicNote.updatedAt})`
+						);
+						window.electronApi.logMessage(
+							`Reusing cached hydration for note ${basicNote.id} (updatedAt: ${basicNote.updatedAt})`,
+							'info'
 						);
 						allNotes.push({
 							...existing,

--- a/tests/gitnews-fetcher-fetch.js
+++ b/tests/gitnews-fetcher-fetch.js
@@ -62,6 +62,21 @@ function makeBasicNote(overrides = {}) {
 	};
 }
 
+function makeHydratedNote(basicNote, overrides = {}) {
+	return {
+		...basicNote,
+		commentUrl: 'https://github.com/owner/repo/issues/1#comment-1',
+		subjectUrl: 'https://github.com/owner/repo/issues/1',
+		commentUsername: 'hydrateduser',
+		commentAvatar: 'https://example.com/avatar.png',
+		api: {
+			subject: { state: 'open', merged: false, draft: false },
+			notification: { reason: basicNote.reason },
+		},
+		...overrides,
+	};
+}
+
 // Create middleware and return a dispatch function + the next spy
 function makeMiddleware(state) {
 	let currentState = state;
@@ -233,6 +248,95 @@ describe('createFetcher() — two-phase fetch', function () {
 			expect(
 				window.electronApi.enrichNotificationsForAccount
 			).toHaveBeenCalledWith(TEST_ACCOUNT, [note]);
+		});
+	});
+
+	describe('Phase 2.5 — hydration cache', function () {
+		it('does not enrich a note that already exists with the same updatedAt', async function () {
+			const basicNote = makeBasicNote({ updatedAt: '2024-01-01T00:00:00Z' });
+			const existingNote = makeHydratedNote(basicNote);
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([basicNote]);
+			const { dispatch } = makeMiddleware(makeState({ notes: [existingNote] }));
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(window.electronApi.enrichNotificationsForAccount).not.toHaveBeenCalled();
+		});
+
+		it('enriches a note when its updatedAt has changed', async function () {
+			const basicNote = makeBasicNote({ updatedAt: '2024-02-01T00:00:00Z' });
+			const existingNote = makeHydratedNote(basicNote, { updatedAt: '2024-01-01T00:00:00Z' });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([basicNote]);
+			const { dispatch } = makeMiddleware(makeState({ notes: [existingNote] }));
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(window.electronApi.enrichNotificationsForAccount).toHaveBeenCalledWith(
+				TEST_ACCOUNT,
+				[basicNote]
+			);
+		});
+
+		it('re-enriches a note that was previously marked invalid', async function () {
+			const basicNote = makeBasicNote({ updatedAt: '2024-01-01T00:00:00Z' });
+			const existingNote = makeHydratedNote(basicNote, { gitnewsIsInvalid: true });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([basicNote]);
+			const { dispatch } = makeMiddleware(makeState({ notes: [existingNote] }));
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(window.electronApi.enrichNotificationsForAccount).toHaveBeenCalledWith(
+				TEST_ACCOUNT,
+				[basicNote]
+			);
+		});
+
+		it('includes cached hydration data in NOTES_RETRIEVED for unchanged notes', async function () {
+			const basicNote = makeBasicNote({ updatedAt: '2024-01-01T00:00:00Z' });
+			const existingNote = makeHydratedNote(basicNote, {
+				commentUrl: 'https://github.com/owner/repo/issues/1#comment-99',
+				commentUsername: 'cacheduser',
+				api: {
+					subject: { state: 'closed', merged: false, draft: false },
+					notification: { reason: 'mention' },
+				},
+			});
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([basicNote]);
+			const { dispatch, next } = makeMiddleware(makeState({ notes: [existingNote] }));
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			const call = next.mock.calls.find((c) => c[0]?.type === 'NOTES_RETRIEVED');
+			expect(call[0].notes[0].commentUrl).toBe(
+				'https://github.com/owner/repo/issues/1#comment-99'
+			);
+			expect(call[0].notes[0].commentUsername).toBe('cacheduser');
+			expect(call[0].notes[0].api.subject.state).toBe('closed');
+		});
+
+		it('updates unread from the fresh basic note even when using cached hydration', async function () {
+			const basicNote = makeBasicNote({ updatedAt: '2024-01-01T00:00:00Z', unread: false });
+			const existingNote = makeHydratedNote(basicNote, { unread: true });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([basicNote]);
+			const { dispatch, next } = makeMiddleware(makeState({ notes: [existingNote] }));
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			const call = next.mock.calls.find((c) => c[0]?.type === 'NOTES_RETRIEVED');
+			expect(call[0].notes[0].unread).toBe(false);
+		});
+
+		it('only enriches notes with changed updatedAt, reusing the rest from cache', async function () {
+			const cachedNote = makeBasicNote({ id: 'n1', updatedAt: '2024-01-01T00:00:00Z' });
+			const updatedNote = makeBasicNote({ id: 'n2', updatedAt: '2024-02-01T00:00:00Z' });
+			const existingN1 = makeHydratedNote(cachedNote);
+			const existingN2 = makeHydratedNote(updatedNote, { updatedAt: '2024-01-15T00:00:00Z' });
+			window.electronApi.listBasicNotificationsForAccount.mockResolvedValue([
+				cachedNote,
+				updatedNote,
+			]);
+			const { dispatch } = makeMiddleware(makeState({ notes: [existingN1, existingN2] }));
+			dispatch({ type: 'GITNEWS_FETCH_NOTIFICATIONS' });
+			await flushPromises();
+			expect(window.electronApi.enrichNotificationsForAccount).toHaveBeenCalledWith(
+				TEST_ACCOUNT,
+				[updatedNote]
+			);
 		});
 	});
 


### PR DESCRIPTION
The current note fetch/enrich flow uses a lot of unnecessary bandwidth because after it refreshes the note list it goes through and fetches details about each note. For unchanged notes (particularly the long tail of read notes) this data is always the same.

In this PR I change the fetch process to skip re-enrichment of existing notes which have not been updated.
