### PR TITLE
Make sure we treat a GHE connection failure as normal failure

### DIFF
--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -52,6 +52,7 @@ interface AppConnectedProps {
 	mutedRepos: string[];
 	offline: boolean;
 	errors: string[];
+	accountsWithFetchErrors: string[];
 	token: string | undefined;
 	lastSuccessfulCheck: number | false;
 	fetchingInProgress: boolean;
@@ -166,17 +167,19 @@ class App extends React.Component<AppProps, AppState> {
 	getNextIcon({
 		offline,
 		errors,
+		accountsWithFetchErrors,
 		unseenNotes,
 		unreadNotes,
 		filterType,
 	}: {
 		offline: boolean;
 		errors: string[];
+		accountsWithFetchErrors: string[];
 		unseenNotes: Note[];
 		unreadNotes: Note[];
 		filterType: FilterType;
 	}) {
-		if (errors.length) {
+		if (errors.length || accountsWithFetchErrors.length) {
 			return 'error';
 		}
 		const unseenNotesFiltered = unseenNotes.filter((note) =>
@@ -206,6 +209,7 @@ class App extends React.Component<AppProps, AppState> {
 			offline,
 			isTokenInvalid,
 			errors,
+			accountsWithFetchErrors,
 			token,
 			lastSuccessfulCheck,
 			getVersion,
@@ -218,6 +222,7 @@ class App extends React.Component<AppProps, AppState> {
 		const nextIcon = this.getNextIcon({
 			offline,
 			errors,
+			accountsWithFetchErrors,
 			unseenNotes,
 			unreadNotes: newNotes,
 			filterType: this.props.filterType,
@@ -330,6 +335,7 @@ function mapStateToProps(state: AppReduxState): AppConnectedProps {
 		mutedRepos: state.mutedRepos,
 		offline: state.offline,
 		errors: state.errors,
+		accountsWithFetchErrors: state.accountsWithFetchErrors,
 		token: state.token,
 		lastSuccessfulCheck: state.lastSuccessfulCheck,
 		fetchingInProgress: state.fetchingInProgress,

--- a/src/renderer/components/config-page.tsx
+++ b/src/renderer/components/config-page.tsx
@@ -57,7 +57,12 @@ export default function ConfigPage({
 						/>
 					</li>
 					<li className="config-row config-row--toggle">
-						<label htmlFor="logging-setting">Enable error logging</label>
+						<div>
+							<label htmlFor="logging-setting">Enable error logging</label>
+							<p className="config-row__hint">
+								Logs are written to ~/Library/Logs/Gitnews/main.log
+							</p>
+						</div>
 						<input
 							type="checkbox"
 							id="logging-setting"

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -364,13 +364,11 @@ function dispatchAccountFetchError(
 		const message = `GitHub Enterprise server for "${account.name}" is temporarily unavailable (server may be starting up)`;
 		debug(message);
 		window.electronApi.logMessage(message, 'warn');
-		dispatch(addConnectionError(message));
 		return;
 	}
 	const message = `Error fetching notifications for "${account.name}": ${getErrorMessage(err as UnknownFetchError)}`;
 	debug(message);
 	window.electronApi.logMessage(message, 'warn');
-	dispatch(addConnectionError(message));
 }
 
 export function getErrorHandler(dispatch: AppDispatch) {

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -364,6 +364,7 @@ function dispatchAccountFetchError(
 		const message = `GitHub Enterprise server for "${account.name}" is temporarily unavailable (server may be starting up)`;
 		debug(message);
 		window.electronApi.logMessage(message, 'warn');
+		dispatch(addConnectionError(message));
 		return;
 	}
 	const message = `Error fetching notifications for "${account.name}": ${getErrorMessage(err as UnknownFetchError)}`;

--- a/src/renderer/lib/reducer.ts
+++ b/src/renderer/lib/reducer.ts
@@ -122,6 +122,7 @@ export function createReducer() {
 			case 'ADD_ACCOUNT_FETCH_ERROR':
 				return {
 					...state,
+					lastChecked: Date.now(),
 					accountsWithFetchErrors: state.accountsWithFetchErrors.includes(
 						action.accountId
 					)

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -210,6 +210,12 @@ button {
 	margin: 0;
 }
 
+.config-row__hint {
+	font-size: 0.8em;
+	opacity: 0.6;
+	margin: 2px 0 0 0;
+}
+
 a {
 	color: var(--main-link-color);
 }


### PR DESCRIPTION
## Proposed changes

Fixes a bug where the app could spin at 100% CPU when a GitHub Enterprise server was temporarily unreachable (e.g. while a SOCKS proxy is still connecting). Also removes noisy raw error details from the UI for per-account fetch failures.

* Set `lastChecked: Date.now()` in the `ADD_ACCOUNT_FETCH_ERROR` reducer case so the poller always gets a real timestamp after any per-account failure
* Remove `addConnectionError` dispatches from `dispatchAccountFetchError` — the existing "Could not fetch notifications" UI message (driven by `accountsWithFetchErrors`) is sufficient; raw technical details stay in the log file only

Before             |  After
:-------------------------:|:-------------------------:
<img width="432" height="602" alt="Screenshot 2026-04-17 at 5 29 31 PM" src="https://github.com/user-attachments/assets/a4d5a07b-ffbd-4b68-a18d-2bc329246d93" /> | <img width="427" height="598" alt="Screenshot 2026-04-17 at 5 38 20 PM" src="https://github.com/user-attachments/assets/ed7c024e-f276-4637-a662-b3665ee40845" />


## Why are these changes being made?

When a per-account fetch fails (e.g. because a GitHub Enterprise server returns an HTML error page while a SOCKS proxy is connecting), `dispatchAccountFetchError` dispatches `addAccountFetchError` to record the failure — but `ADD_ACCOUNT_FETCH_ERROR` never updated `lastChecked`. Everything else that sets `lastChecked` (`NOTES_RETRIEVED`, `ADD_CONNECTION_ERROR`, `OFFLINE`) was only reached on a different code path.

`lastChecked` is what the poller uses to decide when to fetch next. When it is `false` (the initial value), `getSecondsUntilNextFetch` always returns 0 because the math is `fetchInterval - (Date.now() - 0)`, which is an astronomically negative number clamped to zero. The poller therefore treated every tick as "time to fetch" and dispatched a new fetch every second, indefinitely. Each attempt failed the same way, `lastChecked` stayed `false`, and the loop continued — eventually saturating the CPU and making the app unresponsive.

The fix is to set `lastChecked` in `ADD_ACCOUNT_FETCH_ERROR`. Since `addAccountFetchError` is always the first dispatch in `dispatchAccountFetchError`, this covers every per-account failure path without needing `addConnectionError` as a side-effectful workaround. Removing those `addConnectionError` dispatches also cleans up the UX: the header already shows a friendly "Could not fetch notifications for X — check your connection or proxy settings" message via `accountsWithFetchErrors`; the raw socket-level details (e.g. `500; connect ECONNREFUSED 127.0.0.1:8080`) were redundant and unhelpful to users.

## Testing instructions

> [!NOTE]
> This fixes a theoretical bug. I haven't been able to reproduce this myself but I have had reports of a crash due to CPU usage when a proxy connection fails, which this fix may prevent. 

Manual testing:
* Configure a GitHub Enterprise account with a SOCKS proxy. You can simulate a failure by disabling the proxy.
* Launch the app and observe CPU usage — it should stay low
* The header should show "Could not fetch notifications for X" without a raw error in the errors area
* The app should retry after ~2 minutes rather than immediately
