### PR TITLE
Handle RepositoryInvitation notifications with a valid URL

### DIFF
--- a/src/main/lib/github-interface.ts
+++ b/src/main/lib/github-interface.ts
@@ -80,6 +80,13 @@ function getBaseUrlForServer(account: AccountInfo): string | undefined {
 	return `${serverUrl}/api/v3`;
 }
 
+function getWebBaseUrl(account: AccountInfo): string {
+	if (!account.serverUrl || account.serverUrl === mainGithubApiUrl) {
+		return 'https://github.com';
+	}
+	return account.serverUrl.replace(/\/$/, '');
+}
+
 function getOctokitRequestPathFromUrl(
 	account: AccountInfo,
 	urlString: string
@@ -207,6 +214,9 @@ async function getSubjectDataForNotification(
 	let noteDraft: boolean = false;
 	let subjectHtmlUrl: string = '';
 	if (!notification.subject.url) {
+		if (notification.subject.type === 'RepositoryInvitation') {
+			subjectHtmlUrl = `${getWebBaseUrl(account)}/${notification.repository.full_name}/invitations`;
+		}
 		return { noteState, noteMerged, noteDraft, subjectHtmlUrl };
 	}
 	const subjectPath = getOctokitRequestPathFromUrl(

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -238,7 +238,8 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 					if (
 						existing &&
 						existing.updatedAt === basicNote.updatedAt &&
-						!existing.gitnewsIsInvalid
+						!existing.gitnewsIsInvalid &&
+						(existing.subjectUrl || existing.commentUrl)
 					) {
 						debug(
 							`Reusing cached hydration for note ${basicNote.id} (updatedAt: ${basicNote.updatedAt})`


### PR DESCRIPTION
## Problem

Repo invitation notifications (`type: RepositoryInvitation`) have no subject URL in the GitHub API response, so both `subjectUrl` and `commentUrl` are empty strings. Clicking one of these notifications produced a \"Failed to open URL: it is invalid\" error.

## Solution

**`github-interface.ts`**: Added a `getWebBaseUrl` helper and updated `getSubjectDataForNotification` to construct the repo invitations page URL (`{host}/{owner}/{repo}/invitations`) when the notification type is `RepositoryInvitation` and no subject URL exists. Works for both github.com and GitHub Enterprise.

**`gitnews-fetcher.ts`**: The hydration cache was skipping re-enrichment for notes whose `updatedAt` hadn't changed, even if those notes had no usable URL. Added `(existing.subjectUrl || existing.commentUrl)` to the cache-reuse condition so notes without a URL are always re-enriched, fixing previously-cached broken notes on the next fetch.