### PR TITLE
Show username under fallback avatar and fix dev CSP

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -20,7 +20,7 @@ module.exports = {
 			name: '@electron-forge/plugin-webpack',
 			config: {
 				port: 8000,
-				devContentSecurityPolicy: `default-src 'self' *.github.com *.githubusercontent.com localhost:3000 'unsafe-eval' 'unsafe-inline' img-src blob: data:`,
+				devContentSecurityPolicy: `default-src 'self' *.github.com *.githubusercontent.com localhost:3000 'unsafe-eval' 'unsafe-inline'; img-src 'self' https: blob: data:`,
 				mainConfig: './webpack.main.config.js',
 				renderer: {
 					config: './webpack.renderer.config.js',

--- a/src/renderer/components/image-with-backup.tsx
+++ b/src/renderer/components/image-with-backup.tsx
@@ -55,7 +55,14 @@ export function ImageWithBackup({
 		setDidImageFail(true);
 	};
 	if (didImageFail) {
-		return <img src={generateAvatar(username)} />;
+		return (
+			<span className="image-with-backup__fallback">
+				<img src={generateAvatar(username)} alt={username} />
+				<span className="image-with-backup__username" title={username}>
+					{username}
+				</span>
+			</span>
+		);
 	}
-	return <img src={src} onError={onError} />;
+	return <img src={src} alt={username} onError={onError} />;
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -660,6 +660,24 @@ header h1 {
 	position: relative;
 }
 
+.image-with-backup__fallback {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	max-width: 50px;
+}
+
+.image-with-backup__username {
+	font-size: 9px;
+	line-height: 1.1;
+	margin-top: 3px;
+	max-width: 50px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--notification-timestamp-color);
+}
+
 .notification__time {
 	font-size: 0.7em;
 	color: var(--notification-timestamp-color);


### PR DESCRIPTION
## Summary

- For accounts where the comment author's avatar can't be loaded (e.g. proxied GHE avatars per #191), the existing fallback rendered only a single colored initial. Add the full username as a small label directly under the circle (truncated with ellipsis, full username on hover via `title`) so the comment author can actually be identified.
- Fix the dev CSP: the previous value had `img-src` written as a token inside `default-src`, so it was parsed as an (invalid) source rather than its own directive. Split it into a proper `img-src 'self' https: blob: data:` so generated and HTTPS-hosted avatars load reliably and broken loads surface a clean error event for the fallback path.

Before             |  After
:-------------------------:|:-------------------------:
<img width="429" height="98" alt="before-extra-name" src="https://github.com/user-attachments/assets/82d1ebc4-4fa8-4e2d-b31e-2f983e480486" /> | <img width="432" height="98" alt="after-extra-name" src="https://github.com/user-attachments/assets/559d73df-caaa-4a48-803e-857228a87469" />


## Background

While investigating #191 I confirmed that GHE's web-frontend `/avatars/u/<id>` endpoint returns a 302 to the login page for every header-based auth strategy I tried (`token`, `Bearer`, `Basic` with `x-access-token`, and unauthenticated). The endpoint requires a browser session cookie, so a header-based fetch through the main process isn't a viable fix. Improving the fallback was the most useful concrete change to land for now.
