### PR TITLE
Fix position of user icons and add user name to all

### DIFF
--- a/src/renderer/components/image-with-backup.tsx
+++ b/src/renderer/components/image-with-backup.tsx
@@ -54,15 +54,17 @@ export function ImageWithBackup({
 	const onError = () => {
 		setDidImageFail(true);
 	};
-	if (didImageFail) {
-		return (
-			<span className="image-with-backup__fallback">
-				<img src={generateAvatar(username)} alt={username} />
-				<span className="image-with-backup__username" title={username}>
-					{username}
-				</span>
+	const imgSrc = didImageFail ? generateAvatar(username) : src;
+	return (
+		<span className="image-with-backup__wrapper">
+			<img
+				src={imgSrc}
+				alt={username}
+				onError={didImageFail ? undefined : onError}
+			/>
+			<span className="image-with-backup__username" title={username}>
+				{username}
 			</span>
-		);
-	}
-	return <img src={src} alt={username} onError={onError} />;
+		</span>
+	);
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -573,7 +573,7 @@ header h1 {
 .notification__mention-badge {
 	position: absolute;
 	z-index: 1;
-	bottom: 0;
+	top: 3px;
 	right: -4px;
 	width: 14px;
 	height: 14px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -663,13 +663,13 @@ header h1 {
 	position: relative;
 }
 
-.image-with-backup__fallback {
+.image-with-backup__wrapper {
 	display: inline-block;
 	position: relative;
 	vertical-align: top;
 }
 
-.image-with-backup__fallback img {
+.image-with-backup__wrapper img {
 	display: block;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -462,7 +462,7 @@ header svg {
 .mute-icon {
 	position: absolute;
 	z-index: 1;
-	left: -9px;
+	left: -4px;
 	top: 20px;
 	background-color: rgba(255, 255, 255, 0.75);
 	border-radius: 20px;
@@ -612,7 +612,7 @@ header h1 {
 	position: absolute;
 	z-index: 1;
 	font-size: 2.5em;
-	left: -8px;
+	left: -4px;
 	top: 3px;
 	border-radius: 20px;
 	border: 1.2px solid #fff;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -461,6 +461,7 @@ header svg {
 
 .mute-icon {
 	position: absolute;
+	z-index: 1;
 	left: -9px;
 	top: 20px;
 	background-color: rgba(255, 255, 255, 0.75);
@@ -571,6 +572,7 @@ header h1 {
 
 .notification__mention-badge {
 	position: absolute;
+	z-index: 1;
 	bottom: 0;
 	right: -4px;
 	width: 14px;
@@ -608,6 +610,7 @@ header h1 {
 
 .notification__new-dot {
 	position: absolute;
+	z-index: 1;
 	font-size: 2.5em;
 	left: -8px;
 	top: 3px;
@@ -661,17 +664,25 @@ header h1 {
 }
 
 .image-with-backup__fallback {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	max-width: 50px;
+	display: inline-block;
+	position: relative;
+	vertical-align: top;
+}
+
+.image-with-backup__fallback img {
+	display: block;
 }
 
 .image-with-backup__username {
-	font-size: 9px;
-	line-height: 1.1;
+	position: absolute;
+	top: 100%;
+	left: 50%;
+	transform: translateX(-50%);
 	margin-top: 3px;
 	max-width: 50px;
+	font-size: 9px;
+	line-height: 1.1;
+	text-align: center;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;


### PR DESCRIPTION
This is a follow-up to https://github.com/sirbrillig/gitnews-menubar/pull/260 which added the commenter's username below each fallback icon when the user icon cannot be loaded. That PR caused a misalignment of the fallback icons which this PR fixes. This PR also extends the feature so that the username is displayed for all icons, fallback or not, because I find it helpful.
