### PR TITLE
Redesign notification row layout

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,7 +58,7 @@ const bar = menubar({
 	index: MAIN_WINDOW_WEBPACK_ENTRY,
 	icon: getIconForState('loading'),
 	browserWindow: {
-		width: 440,
+		width: 430,
 		height: 600,
 		webPreferences: {
 			nodeIntegration: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,7 +58,7 @@ const bar = menubar({
 	index: MAIN_WINDOW_WEBPACK_ENTRY,
 	icon: getIconForState('loading'),
 	browserWindow: {
-		width: 430,
+		width: 440,
 		height: 600,
 		webPreferences: {
 			nodeIntegration: true,

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -222,10 +222,6 @@ export default function Notification({
 				<MultiMarkUnreadPendingNotice onClick={onClickMarkUnread} />
 			)}
 			<div className="notification__main-content" onClick={onClick}>
-				<div className={iconClasses.join(' ')}>
-					<Gridicon icon={iconType} />
-					<span className="notification__type--text">{iconText}</span>
-				</div>
 				<div className="notification__image">
 					{isUnread && <span className="notification__new-dot" />}
 					{isMuted && <MuteIcon className="mute-icon" />}
@@ -241,7 +237,14 @@ export default function Notification({
 				</div>
 				<div className="notification__body">
 					<div className="notification__repo">
-						<span className="notification__repo-name">
+						<span className={iconClasses.join(' ')}>
+							<Gridicon icon={iconType} />
+							<span className="notification__type--text">{iconText}</span>
+						</span>
+						<span
+							className="notification__repo-name"
+							title={note.repositoryFullName}
+						>
 							{note.repositoryFullName}
 						</span>
 					</div>

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -248,7 +248,9 @@ export default function Notification({
 							{note.repositoryFullName}
 						</span>
 					</div>
-					<div className="notification__title">{note.title}</div>
+					<div className="notification__title" title={note.title}>
+						{note.title}
+					</div>
 					{isInvalid && (
 						<div className="notification__invalid-notice">
 							⚠ Failed to load details

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -229,8 +229,10 @@ export default function Notification({
 				<div className="notification__image">
 					{isUnread && <span className="notification__new-dot" />}
 					{isMuted && <MuteIcon className="mute-icon" />}
-					{isMention && <span className="notification__mention-badge">@</span>}
 					<ImageWithBackup src={avatarSrc} username={note.commentUsername} />
+					{isMention && (
+						<span className="notification__mention-pill">@mention</span>
+					)}
 				</div>
 				<div className="notification__body">
 					<div className="notification__repo">

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { flushSync } from 'react-dom';
 import Gridicon from 'gridicons';
 import debugFactory from 'debug';
 import { formatDistanceToNow } from 'date-fns';
@@ -14,6 +15,18 @@ import {
 	QueuedAction,
 } from '../types';
 import { ImageWithBackup } from './image-with-backup';
+import { getNoteId } from '../lib/helpers';
+
+function runWithViewTransition(update: () => void) {
+	const doc = document as Document & {
+		startViewTransition?: (cb: () => void) => unknown;
+	};
+	if (typeof doc.startViewTransition === 'function') {
+		doc.startViewTransition(() => flushSync(update));
+		return;
+	}
+	update();
+}
 
 const debug = debugFactory('gitnews-menubar');
 
@@ -76,7 +89,7 @@ export default function Notification({
 			queueNoteAction(note, 'markRead');
 			return;
 		}
-		markRead(token, note);
+		runWithViewTransition(() => markRead(token, note));
 	};
 
 	const onClickMarkUnread = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -89,7 +102,7 @@ export default function Notification({
 			queueNoteAction(note, 'markUnread');
 			return;
 		}
-		markUnread(note);
+		runWithViewTransition(() => markUnread(note));
 	};
 
 	const lastUpdated = new Date(note.updatedAt);
@@ -114,6 +127,7 @@ export default function Notification({
 			: []),
 		...getNoteClasses({ isUnread, isMuted, isInvalid }),
 	];
+	const viewTransitionName = `note-${getNoteId(note).replace(/[^\w-]/g, '_')}`;
 	const defaultAvatar = `https://avatars.io/twitter/${note.repositoryFullName}`;
 	const avatarSrc =
 		note.commentAvatar || note.repositoryOwnerAvatar || defaultAvatar;
@@ -156,7 +170,10 @@ export default function Notification({
 
 	if (isMuteRequested) {
 		return (
-			<div className={noteClasses.join(' ')}>
+			<div
+				className={noteClasses.join(' ')}
+				style={{ viewTransitionName: viewTransitionName }}
+			>
 				<div className="notification__mute-confirm">
 					<div className="notification__mute-confirm__text">
 						<div className="notification__mute-confirm__title">
@@ -185,7 +202,10 @@ export default function Notification({
 
 	if (isUnsubscribeRequested) {
 		return (
-			<div className={noteClasses.join(' ')}>
+			<div
+				className={noteClasses.join(' ')}
+				style={{ viewTransitionName: viewTransitionName }}
+			>
 				<div className="notification__mute-confirm">
 					<div className="notification__mute-confirm__text">
 						<div className="notification__mute-confirm__title">
@@ -213,7 +233,10 @@ export default function Notification({
 	}
 
 	return (
-		<div className={noteClasses.join(' ')}>
+		<div
+			className={noteClasses.join(' ')}
+			style={{ viewTransitionName: viewTransitionName }}
+		>
 			{queuedAction === 'open' && <MultiOpenPendingNotice onClick={onClick} />}
 			{queuedAction === 'markRead' && (
 				<MultiMarkReadPendingNotice onClick={onClickMarkRead} />

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -231,7 +231,12 @@ export default function Notification({
 					{isMuted && <MuteIcon className="mute-icon" />}
 					<ImageWithBackup src={avatarSrc} username={note.commentUsername} />
 					{isMention && (
-						<span className="notification__mention-pill">@mention</span>
+						<span
+							className="notification__mention-pill"
+							title="You were mentioned"
+						>
+							@
+						</span>
 					)}
 				</div>
 				<div className="notification__body">

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { flushSync } from 'react-dom';
 import Gridicon from 'gridicons';
 import debugFactory from 'debug';
 import { formatDistanceToNow } from 'date-fns';
@@ -16,17 +15,7 @@ import {
 } from '../types';
 import { ImageWithBackup } from './image-with-backup';
 import { getNoteId } from '../lib/helpers';
-
-function runWithViewTransition(update: () => void) {
-	const doc = document as Document & {
-		startViewTransition?: (cb: () => void) => unknown;
-	};
-	if (typeof doc.startViewTransition === 'function') {
-		doc.startViewTransition(() => flushSync(update));
-		return;
-	}
-	update();
-}
+import { runWithViewTransition } from '../lib/view-transitions';
 
 const debug = debugFactory('gitnews-menubar');
 

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -294,7 +294,9 @@ export default function Notification({
 				onClick={isUnread ? onClickMarkRead : onClickMarkUnread}
 				title={isUnread ? 'Mark as read' : 'Mark as unread'}
 			>
-				<Gridicon icon={isUnread ? 'checkmark' : 'mail'} size={18} />
+				<span className="notification__mark-read-button">
+					<Gridicon icon={isUnread ? 'checkmark' : 'mail'} size={18} />
+				</span>
 			</div>
 		</div>
 	);

--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -257,7 +257,18 @@ export default function Notification({
 						</div>
 					)}
 					<div className="notification__footer">
-						<span className="notification__time">{timeString}</span>
+						<span className="notification__time">
+							{openedRecentlyAt && (
+								<span
+									className="notification__opened-dot"
+									title={`Opened ${formatDistanceToNow(
+										new Date(openedRecentlyAt),
+										{ addSuffix: true }
+									)}`}
+								/>
+							)}
+							{timeString}
+						</span>
 						<span className="notification__actions">
 							{isMuted ? (
 								<UnmuteRepoButton
@@ -276,14 +287,6 @@ export default function Notification({
 							/>
 						</span>
 					</div>
-					{openedRecentlyAt && (
-						<div className="notification__opened-recently">
-							{"opened "}
-							{formatDistanceToNow(new Date(openedRecentlyAt), {
-								addSuffix: true,
-							})}
-						</div>
-					)}
 				</div>
 			</div>
 			<div

--- a/src/renderer/lib/gitnews-fetcher.ts
+++ b/src/renderer/lib/gitnews-fetcher.ts
@@ -1,6 +1,7 @@
 import debugFactory from 'debug';
 import { Middleware } from 'redux';
 import {
+	getNoteId,
 	isAction,
 	isDispatch,
 	secsToMs,
@@ -11,6 +12,7 @@ import {
 	isServerReturningHtml,
 	isTokenInvalid,
 } from '../lib/helpers';
+import { runWithViewTransition } from '../lib/view-transitions';
 import {
 	changeToOffline,
 	fetchBegin,
@@ -174,7 +176,7 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 					`Notifications retrieved (${allNotes.length} found in ${state.accounts.length} accounts)`,
 					'info'
 				);
-				next(gotNotes(allNotes));
+				dispatchGotNotes(state.notes, allNotes, next);
 			} else {
 				type AccountError = {
 					account: AccountInfo;
@@ -318,7 +320,7 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 
 				if (anyAccountSucceeded) {
 					// gotNotes clears errors[], so dispatch it before per-account errors
-					next(gotNotes(allNotes));
+					dispatchGotNotes(state.notes, allNotes, next);
 				}
 
 				for (const { account, err } of allAccountErrors) {
@@ -338,6 +340,27 @@ export function createFetcher(): Middleware<unknown, AppReduxState> {
 	}
 
 	return fetcher;
+}
+
+function notesListSignature(notes: Note[]): string {
+	// Order, identity, and read state all affect the visible list ordering.
+	return notes
+		.map((n) => `${getNoteId(n)}:${n.unread ? 1 : 0}:${n.updatedAt}`)
+		.join('|');
+}
+
+function dispatchGotNotes(
+	previousNotes: Note[],
+	nextNotes: Note[],
+	dispatch: AppDispatch
+) {
+	const visibleChanged =
+		notesListSignature(previousNotes) !== notesListSignature(nextNotes);
+	if (visibleChanged) {
+		runWithViewTransition(() => dispatch(gotNotes(nextNotes)));
+		return;
+	}
+	dispatch(gotNotes(nextNotes));
 }
 
 async function getDemoNotifications(): Promise<Note[]> {

--- a/src/renderer/lib/view-transitions.ts
+++ b/src/renderer/lib/view-transitions.ts
@@ -1,0 +1,12 @@
+import { flushSync } from 'react-dom';
+
+export function runWithViewTransition(update: () => void) {
+	const doc = document as Document & {
+		startViewTransition?: (cb: () => void) => unknown;
+	};
+	if (typeof doc.startViewTransition === 'function') {
+		doc.startViewTransition(() => flushSync(update));
+		return;
+	}
+	update();
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -492,7 +492,6 @@ header svg {
 	fill: var(--config-action-text-color);
 }
 
-
 header h1 {
 	font-size: 1.4em;
 	margin: 0;
@@ -770,8 +769,10 @@ header h1 {
 }
 
 .notification__repo {
-	font-weight: 800;
-	margin-bottom: 5px;
+	font-size: 0.85em;
+	font-weight: 500;
+	color: var(--notification-timestamp-color);
+	margin-bottom: 2px;
 	display: flex;
 	width: 100%;
 	justify-content: space-between;
@@ -823,7 +824,6 @@ header h1 {
 	flex-direction: column;
 	gap: 10px;
 }
-
 
 .no-notifications {
 	padding: 12px;
@@ -1000,7 +1000,6 @@ header h1 {
 	flex-direction: column;
 	justify-content: flex-start;
 }
-
 
 .config-page h3 {
 	margin: 10px 0 4px 0;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -245,6 +245,11 @@ header {
 	z-index: 100;
 	background-color: var(--header-background-color);
 	color: var(--header-text-color);
+	view-transition-name: app-header;
+}
+
+::view-transition-group(app-header) {
+	z-index: 200;
 }
 
 header svg {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -29,6 +29,8 @@
 	--notification-image-background-color: #fff;
 	--no-notifications-icon-color: #000;
 	--filter-button-active-color: #f57023;
+	--avatar-size: 32px;
+	--avatar-badge-offset: 4px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -462,7 +464,7 @@ header svg {
 .mute-icon {
 	position: absolute;
 	z-index: 1;
-	left: -4px;
+	left: calc(50% - var(--avatar-size) / 2 - var(--avatar-badge-offset));
 	top: 20px;
 	background-color: rgba(255, 255, 255, 0.75);
 	border-radius: 20px;
@@ -549,7 +551,7 @@ header h1 {
 }
 
 .notification {
-	padding: 12px 12px 12px 2px;
+	padding: 12px 16px 12px 8px;
 	cursor: pointer;
 	border-top: 1px solid var(--notification-border-color);
 	border-left: 4px solid transparent;
@@ -574,7 +576,7 @@ header h1 {
 	position: absolute;
 	z-index: 1;
 	top: 3px;
-	right: -4px;
+	right: calc(50% - var(--avatar-size) / 2 - var(--avatar-badge-offset));
 	width: 14px;
 	height: 14px;
 	border-radius: 50%;
@@ -612,7 +614,7 @@ header h1 {
 	position: absolute;
 	z-index: 1;
 	font-size: 2.5em;
-	left: -4px;
+	left: calc(50% - var(--avatar-size) / 2 - var(--avatar-badge-offset));
 	top: 3px;
 	border-radius: 20px;
 	border: 1.2px solid #fff;
@@ -626,9 +628,9 @@ header h1 {
 	display: flex;
 	flex-direction: column;
 	font-size: 0.7em;
-	max-width: 50px;
-	min-width: 50px;
-	width: 50px;
+	max-width: 46px;
+	min-width: 46px;
+	width: 46px;
 	align-items: center;
 	overflow: hidden;
 	margin-top: 14px;
@@ -652,15 +654,16 @@ header h1 {
 }
 
 .notification__image img {
-	width: 32px;
+	width: var(--avatar-size);
 	border-radius: 50%;
 	background-color: var(--notification-image-background-color);
 }
 
 .notification__image {
-	margin-right: 10px;
+	min-width: 50px;
 	padding-top: 5px;
 	position: relative;
+	text-align: center;
 }
 
 .image-with-backup__wrapper {
@@ -745,7 +748,8 @@ header h1 {
 
 .notification__body {
 	overflow: hidden;
-	width: 100%;
+	flex: 1;
+	min-width: 200px;
 }
 
 .notification__footer {
@@ -835,6 +839,7 @@ header h1 {
 .notification__main-content {
 	flex: 1;
 	display: flex;
+	gap: 12px;
 	cursor: pointer;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -708,9 +708,14 @@ header h1 {
 	color: var(--notification-timestamp-color);
 }
 
-.notification__opened-recently {
-	font-size: 0.7em;
-	color: #3b82f6;
+.notification__opened-dot {
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	margin-right: 5px;
+	border-radius: 50%;
+	background-color: #3b82f6;
+	vertical-align: 1px;
 }
 
 .notification__mute-confirm__text {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -555,6 +555,7 @@ header h1 {
 
 .notification {
 	padding: 12px 16px 12px 8px;
+	min-height: 80px;
 	cursor: pointer;
 	border-top: 1px solid var(--notification-border-color);
 	border-left: 4px solid transparent;
@@ -760,11 +761,14 @@ header h1 {
 	overflow: hidden;
 	flex: 1;
 	min-width: 200px;
+	display: flex;
+	flex-direction: column;
 }
 
 .notification__footer {
 	display: flex;
 	justify-content: space-between;
+	margin-top: auto;
 }
 
 .notification__actions {
@@ -797,6 +801,10 @@ header h1 {
 	margin-bottom: 5px;
 	overflow-wrap: break-word;
 	word-break: break-word;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
 }
 
 .clear-errors-button {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -785,6 +785,12 @@ header h1 {
 
 .notification__actions {
 	display: flex;
+	opacity: 0.45;
+	transition: opacity 0.15s ease;
+}
+
+.notification:hover .notification__actions {
+	opacity: 1;
 }
 
 .notification__actions button {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -572,23 +572,17 @@ header h1 {
 	border-left: 4px solid #6b7ff5;
 }
 
-.notification__mention-badge {
-	position: absolute;
-	z-index: 1;
-	top: 3px;
-	right: calc(50% - var(--avatar-size) / 2 - var(--avatar-badge-offset));
-	width: 14px;
-	height: 14px;
-	border-radius: 50%;
-	border: 1.2px solid #fff;
-	background: #1a7bd3;
-	color: #fff;
-	font-size: 9px;
+.notification__mention-pill {
+	display: block;
+	width: fit-content;
+	margin: 20px auto 0;
+	padding: 1px 6px;
+	font-size: 0.7em;
 	font-weight: bold;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	line-height: 1;
+	background-color: #1a7bd3;
+	color: #fff;
+	border-radius: 3px;
+	line-height: 1.4;
 }
 
 .notification__muted {
@@ -660,7 +654,7 @@ header h1 {
 }
 
 .notification__image {
-	min-width: 50px;
+	min-width: 64px;
 	padding-top: 5px;
 	position: relative;
 	text-align: center;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -562,6 +562,13 @@ header h1 {
 	position: relative;
 	display: flex;
 	gap: 6px;
+	transition: background-color 0.35s ease;
+}
+
+::view-transition-old(*),
+::view-transition-new(*) {
+	animation-duration: 0.35s;
+	animation-timing-function: ease;
 }
 
 .notification--multi-open {
@@ -889,11 +896,17 @@ header h1 {
 	height: 28px;
 	border-radius: 50%;
 	background-color: rgba(79, 180, 119, 0.12);
-	transition: background-color 0.15s ease;
+	transition:
+		background-color 0.15s ease,
+		transform 0.1s ease;
 }
 
 .notification__mark-read-target:hover .notification__mark-read-button {
 	background-color: rgba(79, 180, 119, 0.25);
+}
+
+.notification__mark-read-target:active .notification__mark-read-button {
+	transform: scale(0.88);
 }
 
 .multi-open-pending-notice {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -878,13 +878,22 @@ header h1 {
 	align-items: center;
 	justify-content: center;
 	cursor: pointer;
-	border-left: 1px solid var(--notification-border-color);
 	fill: #4fb477;
-	transition: background-color 0.2s;
 }
 
-.notification__mark-read-target:hover {
-	background-color: rgba(79, 180, 119, 0.1);
+.notification__mark-read-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 50%;
+	background-color: rgba(79, 180, 119, 0.12);
+	transition: background-color 0.15s ease;
+}
+
+.notification__mark-read-target:hover .notification__mark-read-button {
+	background-color: rgba(79, 180, 119, 0.25);
 }
 
 .multi-open-pending-notice {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -21,6 +21,8 @@
 	--retry-button-text-color: #fff;
 	--offline-notice-background-color: #24292e;
 	--notification-unread-background-color: rgba(245, 112, 35, 0.1);
+	--notification-mention-pill-background-color: #f57023;
+	--notification-mention-pill-text-color: #fff;
 	--notification-timestamp-color: rgb(146, 146, 146);
 	--error-message-color: #d60000;
 	--notification-border-color: #ccc;
@@ -49,6 +51,8 @@
 		--dropdown-selected-text-color: #fff;
 		--search-icon-color: #c9c9c9;
 		--notification-unread-background-color: #172527;
+		--notification-mention-pill-background-color: #f57023;
+		--notification-mention-pill-text-color: #fff;
 		--notification-timestamp-color: #a8a8a8;
 		--notification-border-color: #424242;
 		--multi-open-notification-pending-overlay: rgba(4, 12, 18, 0.85);
@@ -573,16 +577,22 @@ header h1 {
 }
 
 .notification__mention-pill {
-	display: block;
-	width: fit-content;
-	margin: 20px auto 0;
-	padding: 1px 6px;
-	font-size: 0.7em;
-	font-weight: bold;
-	background-color: #1a7bd3;
-	color: #fff;
-	border-radius: 3px;
-	line-height: 1.4;
+	position: absolute;
+	z-index: 1;
+	top: 24px;
+	left: calc(50% + var(--avatar-size) / 2 - 10px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	font-size: 10px;
+	font-weight: 700;
+	line-height: 1;
+	background-color: var(--notification-mention-pill-background-color);
+	color: var(--notification-mention-pill-text-color);
+	border: 1.2px solid var(--main-bg-color);
+	border-radius: 50%;
 }
 
 .notification__muted {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -627,33 +627,40 @@ header h1 {
 }
 
 .notification__type {
-	fill: #28a745;
-	display: flex;
-	flex-direction: column;
-	font-size: 0.7em;
-	max-width: 46px;
-	min-width: 46px;
-	width: 46px;
+	fill: #1a7f37;
+	color: #1a7f37;
+	display: inline-flex;
+	flex: 0 0 auto;
 	align-items: center;
-	overflow: hidden;
-	margin-top: 14px;
+	gap: 3px;
+	margin-right: 6px;
+}
+
+.notification__type--text {
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	font-weight: 600;
+	font-size: 0.85em;
 }
 
 .notification__type--closed {
-	fill: #cb2431;
+	fill: #a40e26;
+	color: #a40e26;
 }
 
 .notification__type--merged {
-	fill: #8957e5;
+	fill: #6f42c1;
+	color: #6f42c1;
 }
 
 .notification__type--draft {
-	fill: #848d97;
+	fill: #6e7681;
+	color: #6e7681;
 }
 
 .notification__type svg {
-	width: 16px;
-	height: 16px;
+	width: 12px;
+	height: 12px;
 }
 
 .notification__image img {
@@ -774,12 +781,16 @@ header h1 {
 	color: var(--notification-timestamp-color);
 	margin-bottom: 2px;
 	display: flex;
+	align-items: center;
 	width: 100%;
-	justify-content: space-between;
 }
 
 .notification__repo-name {
 	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .notification__title {


### PR DESCRIPTION
## Summary

A series of incremental UI tweaks to how each notification row is rendered, aimed at a calmer, denser, more scannable list.

This was inspired because adding the username to the avatar icon in https://github.com/sirbrillig/gitnews-menubar/pull/260 really highlighted the insufficient horizontal space for notes and I figured that we may not really need a whole column just for the notification status.

- **Typographic hierarchy** — repo name demoted to muted metadata above the title, so the title (what the notification is actually about) reads as the lead.
- **Status moved inline** — the dedicated 46px "open / closed / merged / draft" column on the left is gone. The status now lives inline before the repo name as a small-caps colored label.
- **Mention badge** — the full `@mention` pill below the avatar became a small `@` badge tucked into the avatar's bottom-right corner. No more vertical space, no more long-repo-name wrapping.
- **Locked vertical rhythm** — titles clamp to 2 lines with ellipsis (full text on hover), each row has a `min-height`, and the footer (timestamp + actions) is pinned to the bottom edge of the row via flex + `margin-top: auto`.
- **Recently-opened indicator** — the wrapping "opened X ago" line that broke the row rhythm is now a small blue dot before the timestamp with the same info on hover.
- **Mark-read button** — the right-side mail/check icon got a proper button affordance: a soft green tinted circle at rest that darkens on hover, with an `:active` scale-down for click feedback. Vertical divider removed.
- **Animated reordering** — marking a note read/unread used to make the row jump to a new list position abruptly. Wrapping the dispatch in `document.startViewTransition` (with `flushSync`) plus a per-note `view-transition-name` lets the browser smoothly animate the row sliding to its new spot.

Before             |  After
:-------------------------:|:-------------------------:
<img width="434" height="602" alt="gitnews-before-note-redesign" src="https://github.com/user-attachments/assets/6cf64d0e-7027-4dfd-ba32-4b5b21d3070b" /> | <img width="430" height="600" alt="gitnews-after-note-redesign" src="https://github.com/user-attachments/assets/c3babe9d-2e29-46a5-9873-371027bd9c9e" />


## Test plan

- Notification list renders without layout regressions in both light and dark mode
- Long repo names truncate with ellipsis (hover shows full name)
- Long titles clamp to 2 lines with ellipsis (hover shows full title)
- Open / closed / merged / draft labels show with correct colors
- `@` mention badge appears on mention notifications, doesn't appear otherwise
- Marking as read animates the row sliding into the read group (instead of snapping)
- Marking as unread animates the row back up
- Recently-opened blue dot appears next to the timestamp for ~30 min after opening, with a hover tooltip
- Hover and click states on the right-side mark-read/unread button feel correct
