### PR TITLE
Make colors more accessible

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -27,6 +27,7 @@
 	--notification-status-closed-color: #cf222e;
 	--notification-status-merged-color: #8250df;
 	--notification-status-draft-color: #656d76;
+	--notification-status-text-color: #fff;
 	--notification-unread-background-color: rgba(245, 112, 35, 0.1);
 	--notification-mark-read-color: #1a7f37;
 	--error-message-color: #d60000;
@@ -62,6 +63,7 @@
 		--notification-status-closed-color: #f85149;
 		--notification-status-merged-color: #a371f7;
 		--notification-status-draft-color: #8b949e;
+		--notification-status-text-color: #161616;
 		--notification-unread-background-color: rgba(59, 130, 246, 0.16);
 		--notification-mark-read-color: #4fb477;
 		--notification-border-color: #424242;
@@ -650,13 +652,16 @@ header h1 {
 }
 
 .notification__type {
-	fill: var(--notification-status-open-color);
-	color: var(--notification-status-open-color);
 	display: inline-flex;
 	flex: 0 0 auto;
 	align-items: center;
 	gap: 3px;
 	margin-right: 6px;
+	padding: 1px 8px;
+	border-radius: 999px;
+	background-color: var(--notification-status-open-color);
+	color: var(--notification-status-text-color);
+	fill: var(--notification-status-text-color);
 }
 
 .notification__type--text {
@@ -667,18 +672,15 @@ header h1 {
 }
 
 .notification__type--closed {
-	fill: var(--notification-status-closed-color);
-	color: var(--notification-status-closed-color);
+	background-color: var(--notification-status-closed-color);
 }
 
 .notification__type--merged {
-	fill: var(--notification-status-merged-color);
-	color: var(--notification-status-merged-color);
+	background-color: var(--notification-status-merged-color);
 }
 
 .notification__type--draft {
-	fill: var(--notification-status-draft-color);
-	color: var(--notification-status-draft-color);
+	background-color: var(--notification-status-draft-color);
 }
 
 .notification__type svg {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -20,10 +20,15 @@
 	--dropdown-selected-text-color: #000;
 	--retry-button-text-color: #fff;
 	--offline-notice-background-color: #24292e;
-	--notification-unread-background-color: rgba(245, 112, 35, 0.1);
 	--notification-mention-pill-background-color: #f57023;
 	--notification-mention-pill-text-color: #fff;
 	--notification-timestamp-color: rgb(146, 146, 146);
+	--notification-status-open-color: #1a7f37;
+	--notification-status-closed-color: #cf222e;
+	--notification-status-merged-color: #8250df;
+	--notification-status-draft-color: #656d76;
+	--notification-unread-background-color: rgba(245, 112, 35, 0.1);
+	--notification-mark-read-color: #1a7f37;
 	--error-message-color: #d60000;
 	--notification-border-color: #ccc;
 	--search-icon-color: #24292e;
@@ -50,10 +55,15 @@
 		--dropdown-selected-background-color: #2764ff;
 		--dropdown-selected-text-color: #fff;
 		--search-icon-color: #c9c9c9;
-		--notification-unread-background-color: #172527;
 		--notification-mention-pill-background-color: #f57023;
 		--notification-mention-pill-text-color: #fff;
 		--notification-timestamp-color: #a8a8a8;
+		--notification-status-open-color: #3fb950;
+		--notification-status-closed-color: #f85149;
+		--notification-status-merged-color: #a371f7;
+		--notification-status-draft-color: #8b949e;
+		--notification-unread-background-color: rgba(59, 130, 246, 0.16);
+		--notification-mark-read-color: #4fb477;
 		--notification-border-color: #424242;
 		--multi-open-notification-pending-overlay: rgba(4, 12, 18, 0.85);
 		--no-notifications-icon-color: #fff;
@@ -640,8 +650,8 @@ header h1 {
 }
 
 .notification__type {
-	fill: #1a7f37;
-	color: #1a7f37;
+	fill: var(--notification-status-open-color);
+	color: var(--notification-status-open-color);
 	display: inline-flex;
 	flex: 0 0 auto;
 	align-items: center;
@@ -657,18 +667,18 @@ header h1 {
 }
 
 .notification__type--closed {
-	fill: #a40e26;
-	color: #a40e26;
+	fill: var(--notification-status-closed-color);
+	color: var(--notification-status-closed-color);
 }
 
 .notification__type--merged {
-	fill: #6f42c1;
-	color: #6f42c1;
+	fill: var(--notification-status-merged-color);
+	color: var(--notification-status-merged-color);
 }
 
 .notification__type--draft {
-	fill: #6e7681;
-	color: #6e7681;
+	fill: var(--notification-status-draft-color);
+	color: var(--notification-status-draft-color);
 }
 
 .notification__type svg {
@@ -896,7 +906,7 @@ header h1 {
 	align-items: center;
 	justify-content: center;
 	cursor: pointer;
-	fill: #4fb477;
+	fill: var(--notification-mark-read-color);
 }
 
 .notification__mark-read-button {


### PR DESCRIPTION
This PR modifies the notification background color and other colors to be more accessible and easily readable, particularly in dark mode.

Before             |  After
:-------------------------:|:-------------------------:
<img width="432" height="184" alt="Screenshot 2026-06-07 at 3 56 48 PM" src="https://github.com/user-attachments/assets/2c06d32e-2623-46ce-92b2-5d964d44ce3e" /> | <img width="431" height="182" alt="Screenshot 2026-06-07 at 3 56 26 PM" src="https://github.com/user-attachments/assets/46638cbd-95ef-4ec6-93bf-684108bcb971" />
<img width="430" height="182" alt="Screenshot 2026-06-07 at 3 57 26 PM" src="https://github.com/user-attachments/assets/a9c2e522-f37f-4297-a2ef-27ee8dda6e52" /> | <img width="426" height="181" alt="Screenshot 2026-06-07 at 3 57 16 PM" src="https://github.com/user-attachments/assets/837aa824-37a6-4e21-aa95-24c6ad5dbf56" />
<img width="428" height="98" alt="Screenshot 2026-06-07 at 4 00 36 PM" src="https://github.com/user-attachments/assets/395f07e0-510b-41c5-a175-d2a628db4852" /> | <img width="427" height="93" alt="Screenshot 2026-06-07 at 4 01 29 PM" src="https://github.com/user-attachments/assets/ba649e60-1962-49d5-821a-139de58e023a" />
<img width="425" height="98" alt="Screenshot 2026-06-07 at 4 01 53 PM" src="https://github.com/user-attachments/assets/e25b9235-cba5-429c-a199-4fc1bcb213ca" /> | <img width="427" height="97" alt="Screenshot 2026-06-07 at 4 02 10 PM" src="https://github.com/user-attachments/assets/98ccc7d9-58a0-4fc0-ba74-eacc55eda2a0" />
