### PR TITLE
Make confirmation dialogs use same height as notes

### DIFF
--- a/src/renderer/components/notification.tsx
+++ b/src/renderer/components/notification.tsx
@@ -157,19 +157,18 @@ export default function Notification({
 		setUnsubscribeRequested(note);
 	};
 
-	if (isMuteRequested) {
-		return (
-			<div
-				className={noteClasses.join(' ')}
-				style={{ viewTransitionName: viewTransitionName }}
-			>
+	return (
+		<div
+			className={noteClasses.join(' ')}
+			style={{ viewTransitionName: viewTransitionName }}
+		>
+			{isMuteRequested && (
 				<div className="notification__mute-confirm">
 					<div className="notification__mute-confirm__text">
 						<div className="notification__mute-confirm__title">
-							Mute all notifications from {note.repositoryFullName}?
+							Mute {note.repositoryFullName}?
 						</div>
-						Notifications from a muted repo will not cause the icon to change.
-						You can unmute it later.
+						Muted repos won&apos;t change the icon. You can unmute later.
 					</div>
 					<div className="notification__mute-confirm__buttons">
 						<MuteRepoCancelButton
@@ -185,23 +184,15 @@ export default function Notification({
 						/>
 					</div>
 				</div>
-			</div>
-		);
-	}
-
-	if (isUnsubscribeRequested) {
-		return (
-			<div
-				className={noteClasses.join(' ')}
-				style={{ viewTransitionName: viewTransitionName }}
-			>
+			)}
+			{isUnsubscribeRequested && (
 				<div className="notification__mute-confirm">
 					<div className="notification__mute-confirm__text">
 						<div className="notification__mute-confirm__title">
 							Unsubscribe from this thread?
 						</div>
-						You will no longer receive notifications for this thread. This
-						cannot be undone from Gitnews.
+						You&apos;ll stop receiving these. This can&apos;t be undone from
+						Gitnews.
 					</div>
 					<div className="notification__mute-confirm__buttons">
 						<MuteRepoCancelButton
@@ -217,15 +208,7 @@ export default function Notification({
 						/>
 					</div>
 				</div>
-			</div>
-		);
-	}
-
-	return (
-		<div
-			className={noteClasses.join(' ')}
-			style={{ viewTransitionName: viewTransitionName }}
-		>
+			)}
 			{queuedAction === 'open' && <MultiOpenPendingNotice onClick={onClick} />}
 			{queuedAction === 'markRead' && (
 				<MultiMarkReadPendingNotice onClick={onClickMarkRead} />

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -742,19 +742,46 @@ header h1 {
 	vertical-align: 1px;
 }
 
+/* Confirmation overlays (mute repo / unsubscribe) sit on top of the note,
+   filling its full height, so they always match the current note's height
+   and toggling them never shifts the layout. */
+.notification__mute-confirm {
+	position: absolute;
+	z-index: 90;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	background-color: var(--main-bg-color);
+}
+
 .notification__mute-confirm__text {
-	text-align: center;
+	flex: 1;
+	min-width: 0;
+	text-align: left;
 	font-size: 0.9em;
-	padding: 0 10px 10px 10px;
+	color: var(--notification-timestamp-color);
 }
 
 .notification__mute-confirm__title {
 	font-weight: bold;
+	margin-bottom: 2px;
+	color: var(--main-text-color);
 }
 
 .notification__mute-confirm__buttons {
 	display: flex;
-	justify-content: space-evenly;
+	flex-direction: column;
+	gap: 5px;
+	flex: 0 0 auto;
+}
+
+.notification__mute-confirm__buttons button {
+	margin-right: 0;
+	padding: 3px 14px;
+	font-size: 12px;
+	text-align: center;
 }
 
 .btn--cancel {


### PR DESCRIPTION
The recent redesign of notifications set their height to be relatively fixed. However, the confirmation dialogs for muted repos and unsubscribe are too tall for this which causes a layout shift when they open and close. In this PR we make them fit the new note height.

Before             |  After
:-------------------------:|:-------------------------:
<img width="431" height="112" alt="Screenshot 2026-06-07 at 11 30 15 PM" src="https://github.com/user-attachments/assets/a9b07787-cc53-4f25-b48d-b85c538ddfa7" /> | <img width="430" height="84" alt="Screenshot 2026-06-07 at 11 30 03 PM" src="https://github.com/user-attachments/assets/7a3f75f2-e4f1-45c1-ae8c-c413c924774c" />

